### PR TITLE
Feature auto time buffer

### DIFF
--- a/match.py
+++ b/match.py
@@ -32,6 +32,16 @@ class Match:
 
         self.build_successful = self._build(generator1_path, generator2_path, solver1_path, solver2_path, group_nr_one, group_nr_two)
 
+        self.base_build_command = [
+            "docker",
+            "run",
+            "--rm",
+            "--network", "none",
+            "-i",
+            "--memory=" + str(self.space_solver) + "mb",
+            "--cpus=" + str(self.cpus)
+        ]
+
     def _build(self, generator1_path, generator2_path, solver1_path, solver2_path, group_nr_one, group_nr_two):
         """Builds docker containers for the given generators and solvers.
         
@@ -227,27 +237,9 @@ class Match:
         elif not generating_team >= 0 or not solving_team >= 0:
             logger.error('Solving and generating team are expected to be nonnegative ints, received "{}" and "{}".'.format(generating_team, solving_team))
             raise Exception('Solving and generating team are expected to be nonnegative ints!')
-
-        generator_run_command = [
-            "docker",
-            "run",
-            "--rm",
-            "--network", "none",
-            "-i",
-            "--memory=" + str(self.space_generator) + "mb",
-            "--cpus=" + str(self.cpus),
-            "generator" + str(generating_team)
-        ]
-        solver_run_command = [
-            "docker",
-            "run",
-            "--rm",
-            "--network", "none",
-            "-i",
-            "--memory=" + str(self.space_solver) + "mb",
-            "--cpus=" + str(self.cpus),
-            "solver" + str(solving_team)
-        ]
+        
+        generator_run_command = self.base_build_command + ["generator" + str(generating_team)]
+        solver_run_command    = self.base_build_command + ["solver"    + str(solving_team)]
 
         logger.info('Running generator of group {}...\n'.format(generating_team))
 

--- a/problems/delaytest/README.md
+++ b/problems/delaytest/README.md
@@ -1,0 +1,10 @@
+# The Runtime Delay Test
+There is a certain I/O delay when starting and stopping `docker` containers
+depending on the machine that the `run.py` is executed on. This problem is used
+to calculate this overhead for starting and stopping docker containers that do
+nothing but return a little bit of text. The measured maximal overhead is then
+added to the basic runtimes configured in the `config.ini` file.
+
+This problem is not meant to be run on its own. It is automatically invoked by
+the `run.py` at the start of running any problem file as long as the option
+`--no-overhead-calculation` is not set.

--- a/problems/delaytest/__init__.py
+++ b/problems/delaytest/__init__.py
@@ -1,0 +1,1 @@
+from .problem import Delaytest as Problem 

--- a/problems/delaytest/generator/Dockerfile
+++ b/problems/delaytest/generator/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+
+COPY main.sh /
+COPY main.py /
+
+CMD ["./main.sh"]

--- a/problems/delaytest/generator/main.py
+++ b/problems/delaytest/generator/main.py
@@ -1,0 +1,5 @@
+fin = open("input")
+fout = open("output","w")
+n = int(fin.readline())
+fout.write("#" * n)
+fout.close()

--- a/problems/delaytest/generator/main.sh
+++ b/problems/delaytest/generator/main.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+cat > input
+python main.py 1>&2
+cat output
+

--- a/problems/delaytest/parser.py
+++ b/problems/delaytest/parser.py
@@ -1,0 +1,20 @@
+import logging
+
+from parser import Parser
+logger = logging.getLogger('algobattle.parser')
+
+class DelaytestParser(Parser):
+    def split_into_instance_and_solution(self, raw_input):
+        return raw_input, raw_input
+
+    def parse_instance(self, raw_instance, instance_size):
+        return raw_instance
+
+    def parse_solution(self, raw_solution, instance_size):
+        return raw_solution
+
+    def encode(self, input):
+        return super().encode(input)
+
+    def decode(self, raw_input):
+        return raw_input.decode().splitlines()

--- a/problems/delaytest/problem.py
+++ b/problems/delaytest/problem.py
@@ -1,0 +1,12 @@
+import logging
+
+from problem import Problem
+from problems.delaytest.parser import DelaytestParser
+from problems.delaytest.verifier import DelaytestVerifier
+
+logger = logging.getLogger('algobattle.delaytest')
+
+class Delaytest(Problem):
+    n_start = 4
+    parser = DelaytestParser()
+    verifier = DelaytestVerifier()

--- a/problems/delaytest/problem.py
+++ b/problems/delaytest/problem.py
@@ -7,6 +7,6 @@ from problems.delaytest.verifier import DelaytestVerifier
 logger = logging.getLogger('algobattle.delaytest')
 
 class Delaytest(Problem):
-    n_start = 4
+    n_start = 1
     parser = DelaytestParser()
     verifier = DelaytestVerifier()

--- a/problems/delaytest/solver/Dockerfile
+++ b/problems/delaytest/solver/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+
+COPY main.sh /
+COPY main.py /
+
+CMD ["./main.sh"]

--- a/problems/delaytest/solver/main.py
+++ b/problems/delaytest/solver/main.py
@@ -1,0 +1,6 @@
+fin = open("input")
+line = fin.readline()
+
+fout = open("output","w")
+fout.write("#")
+fout.close()

--- a/problems/delaytest/solver/main.sh
+++ b/problems/delaytest/solver/main.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+cat > input
+python main.py 1>&2
+cat output

--- a/problems/delaytest/verifier.py
+++ b/problems/delaytest/verifier.py
@@ -1,0 +1,18 @@
+import logging
+
+from verifier import Verifier
+
+logger = logging.getLogger('algobattle.verifier')
+
+class DelaytestVerifier(Verifier):
+    def verify_semantics_of_instance(self, instance, instance_size: int):
+        return True
+
+    def verify_semantics_of_solution(self, instance, solution, instance_size: int, solution_type: bool):
+        return True
+
+    def verify_solution_against_instance(self, instance, solution, instance_size, solution_type):
+        return True
+
+    def verify_solution_quality(self, instance, instance_size, generator_solution, solver_solution):
+        return True

--- a/run.py
+++ b/run.py
@@ -100,9 +100,12 @@ def main():
         logger.critical('Importing the given problem failed with the following exception: "{}"'.format(e))
         sys.exit(1)
 
+
     runtime_overhead = 0
     if not options.no_overhead_calculation:
+        logger.info('Running a benchmark to determine your machines I/O overhead to start and stop docker containers...')
         runtime_overhead = calculate_time_tolerance()
+        logger.info('Maximal measured runtime overhead is at {} seconds. Adding this amount to the configured runtime.'.format(runtime_overhead))
     match = Match(problem, config, options.generator1_path, options.generator2_path,
                     options.solver1_path, options.solver2_path,
                     int(options.group_nr_one), int(options.group_nr_two), runtime_overhead=runtime_overhead)
@@ -189,7 +192,7 @@ def calculate_time_tolerance():
         float:
             I/O overhead in seconds.
     """
-    logger.info('Running a benchmark to determine your machines I/O overhead to start and stop docker containers...')
+
     Problem = importlib.import_module('problems.delaytest') 
     problem = Problem.Problem()
 
@@ -198,12 +201,11 @@ def calculate_time_tolerance():
                     0, 1)
 
     overheads = []
-    for i in range(0,501,20):
-        _, timeout = match._run_subprocess(match.base_build_command + ["generator0"], input=str(i).encode(), timeout=match.timeout_generator)
+    for i in range(10):
+        _, timeout = match._run_subprocess(match.base_build_command + ["generator0"], input=str(50*i).encode(), timeout=match.timeout_generator)
         overheads.append(float(timeout))
 
     max_overhead = max(overheads)
-    logger.info('Maximal measured runtime overhead is at {} seconds. Adding this amount to the configured runtime.'.format(max_overhead))
 
     return max_overhead
 

--- a/run.py
+++ b/run.py
@@ -32,6 +32,7 @@ parser.add_option('--iterations', dest = 'battle_iterations', type=int, default 
 parser.add_option('--points', dest = 'points', type=int, default = '100', help = 'Number of points for which are fought. Default: 100')
 parser.add_option('--do_not_count_points', dest = 'do_not_count_points', action = 'store_true', help = 'If set, points are not calculated for the run.')
 parser.add_option('-c', '--do_not_log_to_console', dest = 'do_not_log_to_console', action = 'store_true', help = 'Disable forking the logging output to stderr.')
+parser.add_option('--no-overhead-calculation', dest = 'no_overhead_calculation', action = 'store_true', help = 'Log all debug messages.')
 
 (options, args) = parser.parse_args()
 
@@ -99,9 +100,12 @@ def main():
         logger.critical('Importing the given problem failed with the following exception: "{}"'.format(e))
         sys.exit(1)
 
+    runtime_overhead = 0
+    if not options.no_overhead_calculation:
+        runtime_overhead = calculate_time_tolerance()
     match = Match(problem, config, options.generator1_path, options.generator2_path,
                     options.solver1_path, options.solver2_path,
-                    int(options.group_nr_one), int(options.group_nr_two))
+                    int(options.group_nr_one), int(options.group_nr_two), runtime_overhead=runtime_overhead)
 
     if not match.build_successful:
         sys.exit(1)
@@ -155,6 +159,37 @@ def format_summary_message(results0, results1, messages0, messages1, teamA, team
     summary += 'Average solution size of group {}: {}\n'.format(teamB, sum(results1)//int(options.battle_iterations))
 
     return summary
+
+def calculate_time_tolerance():
+    # TODO: Make paths relative to sys.argv[0]
+    logger.info('Running a delay test to determine runtime overhead...')
+    Problem = importlib.import_module('problems.delaytest') 
+    problem = Problem.Problem()
+
+    match = Match(problem, config, 'problems/delaytest/generator', 'problems/delaytest/generator',
+                    'problems/delaytest/solver', 'problems/delaytest/solver',
+                    0, 1)
+
+    generator_run_command = [
+        "docker",
+        "run",
+        "--rm",
+        "--network", "none",
+        "-i",
+        "--memory=" + str(match.space_generator) + "mb",
+        "--cpus=" + str(match.cpus),
+        "generator0"
+    ]
+
+    overheads = []
+    for i in range(0,500,20):
+        _, timeout = match._run_subprocess(generator_run_command, str(i).encode(), match.timeout_generator)
+        overheads.append(float(timeout))
+
+    max_overhead = max(overheads)
+    logger.info('Maximal measured runtime overhead is at {} seconds. Adding this amount to the configured runtime.'.format(max_overhead))
+
+    return max_overhead
 
 if __name__ == "__main__":
     main()

--- a/run.py
+++ b/run.py
@@ -135,6 +135,27 @@ def main():
 
 
 def format_summary_message(results0, results1, messages0, messages1, teamA, teamB):
+    """ Format the results of a battle into a summary message.
+
+        Parameters:
+        ----------
+        results0: list 
+            List of reached instance sizes of teamA.
+        results1: list
+            List of reached instance sizes of teamB.
+        messages0: list
+            Failure messages for each battle of teamA.
+        messages1: list
+            Failure messages for each battle of teamB.
+        teamA: int
+            Group number of teamA.
+        teamB: int
+            Group number of teamB.
+        Returns:
+        ----------
+        str:
+            The formatted summary message.
+    """
     if not len(results0) == len(results1) == len(messages0) == len(messages1) == int(options.battle_iterations):
         return "Number of results and summary messages are not the same!"
     summary = ""
@@ -161,8 +182,14 @@ def format_summary_message(results0, results1, messages0, messages1, teamA, team
     return summary
 
 def calculate_time_tolerance():
-    # TODO: Make paths relative to sys.argv[0]
-    logger.info('Running a delay test to determine runtime overhead...')
+    """ Calculate the I/O delay for starting and stopping docker on the host machine.
+
+        Returns:
+        ----------
+        float:
+            I/O overhead in seconds.
+    """
+    logger.info('Running a benchmark to determine your machines I/O overhead to start and stop docker containers...')
     Problem = importlib.import_module('problems.delaytest') 
     problem = Problem.Problem()
 
@@ -170,20 +197,9 @@ def calculate_time_tolerance():
                     'problems/delaytest/solver', 'problems/delaytest/solver',
                     0, 1)
 
-    generator_run_command = [
-        "docker",
-        "run",
-        "--rm",
-        "--network", "none",
-        "-i",
-        "--memory=" + str(match.space_generator) + "mb",
-        "--cpus=" + str(match.cpus),
-        "generator0"
-    ]
-
     overheads = []
-    for i in range(0,500,20):
-        _, timeout = match._run_subprocess(generator_run_command, str(i).encode(), match.timeout_generator)
+    for i in range(0,501,20):
+        _, timeout = match._run_subprocess(match.base_build_command + ["generator0"], input=str(i).encode(), timeout=match.timeout_generator)
         overheads.append(float(timeout))
 
     max_overhead = max(overheads)


### PR DESCRIPTION
Add a function that calculates the maximum I/O overhead on a target machine. This can be optionally used to ensure that the running time configured in `config.ini` can be used without additional time buffers to prevent unexpected timeouts.