### PR TITLE
Runtime overhead fix

### DIFF
--- a/algobattle/config/config_delaytest.ini
+++ b/algobattle/config/config_delaytest.ini
@@ -1,0 +1,18 @@
+#Please do not change the values in this config file.
+[run_parameters]
+# Time for building the docker container (in seconds)
+timeout_build           = 30
+# Runtime cap for the generator (in seconds)
+timeout_generator       = 300
+# Runtime cap for the solver (in seconds)
+timeout_solver          = 5
+# Memory assigned to the generator to use in its run (in mb)
+space_generator         = 500
+# Memory assigned to the solver to use in its run (in mb)
+space_solver            = 500
+# Number of threads that the solver and the generator may use
+cpus                    = 1
+# Iteration cutoff after which an iterated battle is automatically stopped, declaring the solver as the winner
+iteration_cap           = 1
+# Number of iterations for an averaged battle between two teams.
+aproximation_iterations = 1

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -42,7 +42,7 @@ class Match:
             logger.error('The given problem is not approximable and can only be run with an approximation ratio of 1.0!')
             self.build_successful = False
 
-        self.base_build_command = [
+        self.base_run_command = [
             "docker",
             "run",
             "--rm",
@@ -100,7 +100,7 @@ class Match:
         Bool
             Boolean indicating whether the build process succeeded.
         """
-        docker_build_base = [
+        base_build_command = [
             "docker",
             "build",
         ] + (["--no-cache"] if not cache_docker_containers else []) + [
@@ -123,8 +123,8 @@ class Match:
             self.single_player = True
 
         for team in teams:
-            build_commands.append(docker_build_base + ["solver-" + str(team.name), team.solver_path])
-            build_commands.append(docker_build_base + ["generator-" + str(team.name), team.generator_path])
+            build_commands.append(base_build_command + ["solver-" + str(team.name), team.solver_path])
+            build_commands.append(base_build_command + ["generator-" + str(team.name), team.generator_path])
 
         for command in build_commands:
             logger.debug('Building docker container with the following command: {}'.format(command))
@@ -315,8 +315,8 @@ class Match:
             logger.error('Expected an instance size to be an int of size at least 1, received: {}'.format(instance_size))
             raise Exception('Expected the instance size to be a positive integer.')
 
-        generator_run_command = self.base_build_command + ["generator-" + str(self.generating_team)]
-        solver_run_command    = self.base_build_command + ["solver-"    + str(self.solving_team)]
+        generator_run_command = self.base_run_command + ["generator-" + str(self.generating_team)]
+        solver_run_command    = self.base_run_command + ["solver-"    + str(self.solving_team)]
 
         logger.info('Running generator of group {}...\n'.format(self.generating_team))
 

--- a/algobattle/problems/delaytest/README.md
+++ b/algobattle/problems/delaytest/README.md
@@ -1,10 +1,10 @@
 # The Runtime Delay Test
 There is a certain I/O delay when starting and stopping `docker` containers
-depending on the machine that the `run.py` is executed on. This problem is used
+depending on the machine that the `battle` is executed on. This problem is used
 to calculate this overhead for starting and stopping docker containers that do
 nothing but return a little bit of text. The measured maximal overhead is then
-added to the basic runtimes configured in the `config.ini` file.
+added to the basic runtimes given in the config file used in the run.
 
 This problem is not meant to be run on its own. It is automatically invoked by
-the `run.py` at the start of running any problem file as long as the option
+the `battle` at the start of running any problem file as long as the option
 `--no-overhead-calculation` is not set.

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -49,21 +49,23 @@ def measure_runtime_overhead() -> float:
         I/O overhead in seconds, rounded to two decimal places.
     """
     problem = DelaytestProblem.Problem()
-
+    config_path = os.path.join(os.path.dirname(os.path.abspath(algobattle.__file__)), 'config', 'config_delaytest.ini')
     delaytest_path = DelaytestProblem.__file__[:-12]  # remove /__init__.py
     delaytest_team = algobattle.team.Team(0, delaytest_path + '/generator', delaytest_path + '/solver')
-
-    config_path = os.path.join(os.path.dirname(os.path.abspath(algobattle.__file__)), 'config', 'config.ini')
+    
     match = algobattle.match.Match(problem, config_path, [delaytest_team])
 
     if not match.build_successful:
         logger.warning('Building a match for the time tolerance calculation failed!')
         return 0
+
     overheads = []
-    for i in range(10):
+    for i in range(5):
         sigh.latest_running_docker_image = "generator0"
-        _, timeout = run_subprocess(match.base_build_command + ["generator0"],
+        _, timeout = run_subprocess(match.base_run_command + ["generator0"],
                                     input=str(50 * i).encode(), timeout=match.timeout_generator)
+        if not timeout:
+            timeout = match.timeout_generator
         overheads.append(float(timeout))
 
     max_overhead = round(max(overheads), 2)

--- a/scripts/battle
+++ b/scripts/battle
@@ -96,7 +96,9 @@ if __name__ == "__main__":
         sys.exit('The number of provided generator paths ({}), solver paths ({}) and group numbers ({}) is not equal!'.format(len(generators), len(solvers), len(team_names)))
 
     if not os.path.exists(problem_path):
-        sys.exit('Input path "{}" does not exist in the file system! Use "battle --help" for more information on usage and options.'.format(problem_path))
+        sys.exit('Problem path "{}" does not exist in the file system! Use "battle --help" for more information on usage and options.'.format(problem_path))
+    if not os.path.exists(options.config):
+        sys.exit('Config path "{}" does not exist in the file system! Use "battle --help" for more information on usage and options.'.format(problem_path))
     for solver_path in solvers:
         if not os.path.exists(solver_path):
             sys.exit('The given path for option --solvers "{}" does not exist in the file system! Use "battle --help" for more information on usage and options.'.format(solver_path))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='algobattle',
-    version='0.1.0',
+    version='1.0.1',
     packages=['algobattle'],
     scripts=['scripts/battle'],
     python_requires='>=3.6',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -48,7 +48,7 @@ class Matchtests(unittest.TestCase):
     def test_run_subprocess(self):
         team = Team('0', self.tests_path + '/generator_timeout', self.tests_path + '/solver')
         match_run_timeout = Match(self.problem, self.config, [team])
-        raw_output, _ = run_subprocess(match_run_timeout.base_build_command + ['generator-0'], 0, 2)
+        raw_output, _ = run_subprocess(match_run_timeout.base_run_command + ['generator-0'], 0, 2)
         self.assertIsNone(raw_output)
 
 


### PR DESCRIPTION
In the case of slower disks, the `measure_runtime_overhead` function could easily run into the 30 second timeout configured in the `config/config.ini`. When this happened, `None` was returned as a runtime which was not handled and caused a crash.

This case is now handled and a special config for the `delaytest` problem was added. This is due to the function using the default configuration up to now, which very reasonably could change on the disk and set overheads that are too optimistic.

While testing, it was also discovered that the `battle` script did not check if a path given by the  `--config_file` option exists on the file system. A corresponding check was added.

The attribute `base_build_command` of the `match` object was renamed to `base_run_command`, as this captures its functionality more closely.