### PR TITLE
Refactor ci

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,6 +30,7 @@ jobs:
         path: .
 
   lint:
+    needs: build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@master
@@ -46,6 +47,7 @@ jobs:
         --docstring-convention numpy --show-source --statistics --ignore=D105,D401
 
   test:
+    needs: build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@master
@@ -57,6 +59,7 @@ jobs:
         python -m unittest
 
   execute:
+    needs: build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@master

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -57,7 +57,6 @@ jobs:
         pip install . --user
     - name: Run short battles with different options as a sanity check
       run: |
-        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --no_overhead_calculation
-        --generators=algobattle/problems/testsproblem/generator,algobattle/problems/testsproblem/generator \
-        --solvers=algobattle/problems/testsproblem/solver,algobattle/problems/testsproblem/solver --team_names=team1,team2
+        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2
+        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --no_overhead_calculation --generators=algobattle/problems/testsproblem/generator,algobattle/problems/testsproblem/generator --solvers=algobattle/problems/testsproblem/solver,algobattle/problems/testsproblem/solver --team_names=team1,team2
         $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.6
@@ -25,25 +24,50 @@ jobs:
         pip install flake8 flake8-docstrings
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install . --user
+    - uses: actions/upload-artifact@master
+      with:
+        name: algo-artifact
+        path: .
+
   lint:
-    name: Lint with flake8
-    run: |
-      flake8 . --count --max-complexity=10  --max-line-length=127  \
-      --per-file-ignores="__init__.py:F401,D104 */solver_execution_error/main.py:E999 \
-      */generator_execution_error/main.py:E999 match.py:E221 setup.py:D102,D100 \
-      */problems/*/verifier.py:D102 */problems/*/parser.py:D102 tests/*:D102 tests/__init__.py:D104 \
-      scripts/battle:E501,C901" \
-      --docstring-convention numpy --show-source --statistics --ignore=D105,D401
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@master
+      with:
+        name: algo-artifact
+        path: .
+    - name: Lint with flake8
+      run: |
+        flake8 . --count --max-complexity=10  --max-line-length=127  \
+        --per-file-ignores="__init__.py:F401,D104 */solver_execution_error/main.py:E999 \
+        */generator_execution_error/main.py:E999 match.py:E221 setup.py:D102,D100 \
+        */problems/*/verifier.py:D102 */problems/*/parser.py:D102 tests/*:D102 tests/__init__.py:D104 \
+        scripts/battle:E501,C901" \
+        --docstring-convention numpy --show-source --statistics --ignore=D105,D401
+
   test:
-    name: Test using unittests
-    run: |
-      python -m unittest
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@master
+      with:
+        name: algo-artifact
+        path: .
+    - name: Test using unittests
+      run: |
+        python -m unittest
+
   execute:
-    name: Run short battles with different options as a sanity check
-    run: |
-      $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --no_overhead_calculation
-      $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --ui \
-      --generators=algobattle/problems/testsproblem/generator,algobattle/problems/testsproblem/generator \
-      --solvers=algobattle/problems/testsproblem/solver,algobattle/problems/testsproblem/solver --team_names=team1,team2
-      $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2
-      $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2 --ui
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@master
+      with:
+        name: algo-artifact
+        path: .
+    - name: Run short battles with different options as a sanity check
+      run: |
+        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --no_overhead_calculation
+        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --ui \
+        --generators=algobattle/problems/testsproblem/generator,algobattle/problems/testsproblem/generator \
+        --solvers=algobattle/problems/testsproblem/solver,algobattle/problems/testsproblem/solver --team_names=team1,team2
+        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2
+        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2 --ui

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -58,8 +58,6 @@ jobs:
     - name: Run short battles with different options as a sanity check
       run: |
         $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --no_overhead_calculation
-        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --ui \
         --generators=algobattle/problems/testsproblem/generator,algobattle/problems/testsproblem/generator \
         --solvers=algobattle/problems/testsproblem/solver,algobattle/problems/testsproblem/solver --team_names=team1,team2
         $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2
-        $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2 --ui

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,20 +26,20 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install . --user
   lint:
-    - name: Lint with flake8
-      run: |
-        flake8 . --count --max-complexity=10  --max-line-length=127  \
-        --per-file-ignores="__init__.py:F401,D104 */solver_execution_error/main.py:E999 \
-        */generator_execution_error/main.py:E999 match.py:E221 setup.py:D102,D100 \
-        */problems/*/verifier.py:D102 */problems/*/parser.py:D102 tests/*:D102 tests/__init__.py:D104 \
-        scripts/battle:E501,C901" \
-        --docstring-convention numpy --show-source --statistics --ignore=D105,D401
+    name: Lint with flake8
+    run: |
+      flake8 . --count --max-complexity=10  --max-line-length=127  \
+      --per-file-ignores="__init__.py:F401,D104 */solver_execution_error/main.py:E999 \
+      */generator_execution_error/main.py:E999 match.py:E221 setup.py:D102,D100 \
+      */problems/*/verifier.py:D102 */problems/*/parser.py:D102 tests/*:D102 tests/__init__.py:D104 \
+      scripts/battle:E501,C901" \
+      --docstring-convention numpy --show-source --statistics --ignore=D105,D401
   test:
-    - name: Test using unittests
-      run: |
-        python -m unittest
+    name: Test using unittests
+    run: |
+      python -m unittest
   execute:
-    -name: Run short battles with different options as a sanity check
+    name: Run short battles with different options as a sanity check
     run: |
       $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --no_overhead_calculation
       $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --ui \

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -26,16 +25,25 @@ jobs:
         pip install flake8 flake8-docstrings
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install . --user
+  lint:
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics \
-        --per-file-ignores="*/solver_execution_error/main.py:E999 */generator_execution_error/main.py:E999"
-        # The GitHub editor is 127 chars wide
-        flake8 . --count --max-complexity=10 --max-line-length=127 --statistics \
+        flake8 . --count --max-complexity=10  --max-line-length=127  \
         --per-file-ignores="__init__.py:F401,D104 */solver_execution_error/main.py:E999 \
-        */generator_execution_error/main.py:E999 match.py:E221 */solver/main.py:D100 */generator/main.py:D100" \
-        --docstring-convention numpy --ignore=D100,D105,D102,W503
-    - name: Test with unittest
+        */generator_execution_error/main.py:E999 match.py:E221 setup.py:D102,D100 \
+        */problems/*/verifier.py:D102 */problems/*/parser.py:D102 tests/*:D102 tests/__init__.py:D104 \
+        scripts/battle:E501,C901" \
+        --docstring-convention numpy --show-source --statistics --ignore=D105,D401
+  test:
+    - name: Test using unittests
       run: |
         python -m unittest
+  execute:
+    -name: Run short battles with different options as a sanity check
+    run: |
+      $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --no_overhead_calculation
+      $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --ui \
+      --generators=algobattle/problems/testsproblem/generator,algobattle/problems/testsproblem/generator \
+      --solvers=algobattle/problems/testsproblem/solver,algobattle/problems/testsproblem/solver --team_names=team1,team2
+      $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2
+      $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --battle_type=averaged --approx_ratio=1.5 --approx_inst_size=3 --approx_iterations=3 --round=2 --ui

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,7 +10,7 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -22,21 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 flake8-docstrings
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install . --user
-    - uses: actions/upload-artifact@master
-      with:
-        name: algo-artifact
-        path: .
-
-  lint:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/download-artifact@master
-      with:
-        name: algo-artifact
-        path: .
     - name: Lint with flake8
       run: |
         flake8 . --count --max-complexity=10  --max-line-length=127  \
@@ -47,25 +32,29 @@ jobs:
         --docstring-convention numpy --show-source --statistics --ignore=D105,D401
 
   test:
-    needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@master
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
       with:
-        name: algo-artifact
-        path: .
+        python-version: 3.6
     - name: Test using unittests
       run: |
         python -m unittest
 
   execute:
-    needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@master
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
       with:
-        name: algo-artifact
-        path: .
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install . --user
     - name: Run short battles with different options as a sanity check
       run: |
         $HOME/.local/bin/battle algobattle/problems/testsproblem --verbose --iter_cap=5 --rounds=2 --no_overhead_calculation

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/__pycache__
 algobattle.egg-info/*
+.vscode/*

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -1,3 +1,4 @@
+"""Match class, provides functionality for setting up and executing battles between given teams."""
 import subprocess
 
 import logging

--- a/algobattle/parser.py
+++ b/algobattle/parser.py
@@ -1,3 +1,4 @@
+"""Abstract base class for parsers used in concrete problem implementations."""
 from abc import ABC, abstractmethod
 from typing import Tuple
 

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -1,3 +1,4 @@
+"""Abstract base class for problem classes used in concrete problem implementations."""
 from abc import ABCMeta, abstractmethod
 
 
@@ -12,26 +13,31 @@ class Problem(metaclass=ABCMeta):
     @property
     @abstractmethod
     def name(self):
+        """Name of a Problem."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def n_start(self):
+        """Lowest value on which a battle should be executed."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def parser(self):
+        """Parser object for the corresponding problem."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def verifier(self):
+        """Verifier object for the corresponding problem."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def approximable(self):
+        """Boolean flag indicating whether a problem can have an approximate solution."""
         raise NotImplementedError
 
     def __str__(self) -> str:

--- a/algobattle/problems/delaytest/generator/main.py
+++ b/algobattle/problems/delaytest/generator/main.py
@@ -1,6 +1,6 @@
-fin = open("input")
-fout = open("output", "w")
-
-n = int(fin.readline())
-fout.write("#" * n)
-fout.close()
+"""Dummy solver for the delaytest problem. Outputs n # signs, where n is the read input."""
+n = 0
+with open("input", "r") as input:
+    n = int(input.readline())
+with open("output", "w") as output:
+    output.write("#" * n)

--- a/algobattle/problems/delaytest/parser.py
+++ b/algobattle/problems/delaytest/parser.py
@@ -1,3 +1,4 @@
+"""Dummy parser for delaytest. No actual parsing is done, the input and output are simply forwarded."""
 import logging
 
 from algobattle.parser import Parser

--- a/algobattle/problems/delaytest/problem.py
+++ b/algobattle/problems/delaytest/problem.py
@@ -1,3 +1,4 @@
+"""Dummy problem class for delaytest."""
 import logging
 
 from algobattle.problem import Problem

--- a/algobattle/problems/delaytest/solver/main.py
+++ b/algobattle/problems/delaytest/solver/main.py
@@ -1,6 +1,3 @@
-fin = open("input")
-line = fin.readline()
-
-fout = open("output", "w")
-fout.write("#")
-fout.close()
+"""Dummy generator for delaytest. Outputs a # sign."""
+with open("output", "w") as out:
+    out.write("#")

--- a/algobattle/problems/delaytest/verifier.py
+++ b/algobattle/problems/delaytest/verifier.py
@@ -1,5 +1,5 @@
+"""Dummy verifier for the delaytest. Does not verify anything."""
 import logging
-
 from algobattle.verifier import Verifier
 
 logger = logging.getLogger('algobattle.problems.delaytest.verifier')

--- a/algobattle/problems/testsproblem/generator/main.py
+++ b/algobattle/problems/testsproblem/generator/main.py
@@ -1,5 +1,3 @@
-fin = open("input")
-fout = open("output", "w")
-
-fout.write("i 1\ns 1 1 1")
-fout.close()
+"""Simple generator that outputs a static instance and certificate."""
+with open("output", "w") as output:
+    output.write("i 1\ns 1 1 1")

--- a/algobattle/problems/testsproblem/generator_build_error/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_build_error/Dockerfile
@@ -1,8 +1,3 @@
 FROM python:3
 
 BUILD AN ERROR
-
-COPY main.sh /
-COPY main.py /
-
-CMD ["./main.sh"]

--- a/algobattle/problems/testsproblem/generator_build_error/main.py
+++ b/algobattle/problems/testsproblem/generator_build_error/main.py
@@ -1,6 +1,0 @@
-fin = open("input")
-fout = open("output", "w")
-n = int(fin.readline())
-
-fout.write("s ds 1\ns ds 4\ne 1 2\ne 2 3\ne 3 4\ne 4 5\ne 5 6\ne 6 1\ne 2 6\ne 3 5")
-fout.close()

--- a/algobattle/problems/testsproblem/generator_build_error/main.sh
+++ b/algobattle/problems/testsproblem/generator_build_error/main.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-cat > input
-python main.py 1>&2
-cat output
-

--- a/algobattle/problems/testsproblem/generator_build_timeout/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_build_timeout/Dockerfile
@@ -1,8 +1,3 @@
 FROM python:3
 
 RUN sleep 6000;
-
-COPY main.sh /
-COPY main.py /
-
-CMD ["./main.sh"]

--- a/algobattle/problems/testsproblem/generator_build_timeout/main.py
+++ b/algobattle/problems/testsproblem/generator_build_timeout/main.py
@@ -1,6 +1,0 @@
-fin = open("input")
-fout = open("output", "w")
-n = int(fin.readline())
-
-fout.write("s ds 1\ns ds 4\ne 1 2\ne 2 3\ne 3 4\ne 4 5\ne 5 6\ne 6 1\ne 2 6\ne 3 5")
-fout.close()

--- a/algobattle/problems/testsproblem/generator_build_timeout/main.sh
+++ b/algobattle/problems/testsproblem/generator_build_timeout/main.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-cat > input
-python main.py 1>&2
-cat output
-

--- a/algobattle/problems/testsproblem/generator_execution_error/main.py
+++ b/algobattle/problems/testsproblem/generator_execution_error/main.py
@@ -1,1 +1,2 @@
+"""Generator that contains malformed python code. Should cause an error."""
 print This python script is broken

--- a/algobattle/problems/testsproblem/generator_malformed_solution/main.py
+++ b/algobattle/problems/testsproblem/generator_malformed_solution/main.py
@@ -1,5 +1,3 @@
-fin = open("input")
-fout = open("output", "w")
-
-fout.write("i 1\ns 0 1")
-fout.close()
+"""Generator that outputs a static, artificially malformed solution."""
+with open("output", "w") as output:
+    output.write("i 1\ns 0 1")

--- a/algobattle/problems/testsproblem/generator_timeout/main.py
+++ b/algobattle/problems/testsproblem/generator_timeout/main.py
@@ -1,3 +1,4 @@
+"""Simple generator that only sleeps for 1000000 seconds, trying to cause an execution timeout."""
 import time
 
 time.sleep(1000000)

--- a/algobattle/problems/testsproblem/generator_wrong_certificate/main.py
+++ b/algobattle/problems/testsproblem/generator_wrong_certificate/main.py
@@ -1,5 +1,3 @@
-fin = open("input")
-fout = open("output", "w")
-
-fout.write("i 1\ns 1 0")
-fout.close()
+"""Simple generator that outputs a static string encoding an instance with an artificially wrong certificate."""
+with open("output", "w") as output:
+    output.write("i 1\ns 1 0")

--- a/algobattle/problems/testsproblem/generator_wrong_instance/main.py
+++ b/algobattle/problems/testsproblem/generator_wrong_instance/main.py
@@ -1,5 +1,3 @@
-fin = open("input")
-fout = open("output", "w")
-
-fout.write("i 0\ns 1")
-fout.close()
+"""Simple generator that outputs a semantically wrong instance."""
+with open("output", "w") as output:
+    output.write("i 0\ns 1")

--- a/algobattle/problems/testsproblem/parser.py
+++ b/algobattle/problems/testsproblem/parser.py
@@ -1,3 +1,4 @@
+"""Dummy parser built for tests."""
 import logging
 
 from algobattle.parser import Parser

--- a/algobattle/problems/testsproblem/problem.py
+++ b/algobattle/problems/testsproblem/problem.py
@@ -1,3 +1,4 @@
+"""Problem class built for tests."""
 import logging
 
 from algobattle.problem import Problem
@@ -14,4 +15,4 @@ class Tests(Problem):
     n_start = 1
     parser = TestsParser()
     verifier = TestsVerifier()
-    approximable = False
+    approximable = True

--- a/algobattle/problems/testsproblem/solver/main.py
+++ b/algobattle/problems/testsproblem/solver/main.py
@@ -1,6 +1,3 @@
-fin = open("input")
-line = fin.readline()
-
-fout = open("output", "w")
-fout.write("s 1 1 1")
-fout.close()
+"""Simple solver that outputs a static solution."""
+with open("output", "w") as output:
+    output.write("s 1 1 1")

--- a/algobattle/problems/testsproblem/solver_execution_error/main.py
+++ b/algobattle/problems/testsproblem/solver_execution_error/main.py
@@ -1,1 +1,2 @@
+"""Solver that contains malformed python code. Should cause an error."""
 print This python script is broken

--- a/algobattle/problems/testsproblem/solver_malformed_solution/main.py
+++ b/algobattle/problems/testsproblem/solver_malformed_solution/main.py
@@ -1,6 +1,3 @@
-fin = open("input")
-line = fin.readline()
-
-fout = open("output", "w")
-fout.write("s 0 1 1")
-fout.close()
+"""Simple solver that outputs a static, semantically wrong solution."""
+with open("output", "w") as output:
+    output.write("s 0 1 1")

--- a/algobattle/problems/testsproblem/solver_timeout/main.py
+++ b/algobattle/problems/testsproblem/solver_timeout/main.py
@@ -1,3 +1,4 @@
+"""Simple solver that only sleeps for 1000000 seconds, trying to cause an execution timeout."""
 import time
 
 time.sleep(1000000)

--- a/algobattle/problems/testsproblem/solver_wrong_certificate/main.py
+++ b/algobattle/problems/testsproblem/solver_wrong_certificate/main.py
@@ -1,5 +1,3 @@
-fin = open("input")
-fout = open("output", "w")
-
-fout.write("s 1 0 1")
-fout.close()
+"""Simple solver that outputs a static, artificially wrong solution."""
+with open("output", "w") as output:
+    output.write("s 1 0 1")

--- a/algobattle/problems/testsproblem/verifier.py
+++ b/algobattle/problems/testsproblem/verifier.py
@@ -1,3 +1,4 @@
+"""Simple verifier hand-tailored for certain tests to succeed or fail."""
 import logging
 
 from algobattle.verifier import Verifier

--- a/algobattle/sighandler.py
+++ b/algobattle/sighandler.py
@@ -1,3 +1,4 @@
+"""Implementations used to safely kill a running battle, cleaning up possibly running docker containers."""
 import signal
 import sys
 import logging

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -1,3 +1,6 @@
+"""Team class, stores necessary information about a Team, such as their associated solver and generator."""
+
+
 class Team:
     """Team class responsible for holding basic information of a specific team."""
 

--- a/algobattle/verifier.py
+++ b/algobattle/verifier.py
@@ -1,3 +1,4 @@
+"""Abstract base class for verifiers used in concrete problem implementations."""
 from abc import ABC, abstractmethod
 import logging
 

--- a/scripts/battle
+++ b/scripts/battle
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     parser.add_option('--points', dest='points', type=int, default='100', help='Number of points for which are fought. Default: 100')
     parser.add_option('--do_not_count_points', dest='do_not_count_points', action='store_true', help='If set, points are not calculated for the run.')
     parser.add_option('--silent', dest='silent', action='store_true', help='Disable forking the logging output to stderr.')
-    parser.add_option('--no-overhead-calculation', dest='no_overhead_calculation', action='store_true', help='If set, the program does not benchmark the I/O of the host system to calculate the runtime overhead when started.')
+    parser.add_option('--no_overhead_calculation', dest='no_overhead_calculation', action='store_true', help='If set, the program does not benchmark the I/O of the host system to calculate the runtime overhead when started.')
     parser.add_option('--ui', dest='display_ui', action='store_true', help='If set, the program sets the --silent option and displays a small ui on STDOUT that shows the progress of the battles. Currently only works for iterated battles.')
 
     (options, args) = parser.parse_args()

--- a/scripts/battle
+++ b/scripts/battle
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Main battle script. Executes all possible types of battles, see battle --help for all options."""
 import sys
 import os
 import logging
@@ -16,7 +17,7 @@ from algobattle.ui import Ui
 if __name__ == "__main__":
 
     def setup_logging(logging_path, verbose_logging, silent):
-        """ Creates and returns a parent logger.
+        """Creates and returns a parent logger.
 
         Parameters:
         ----------
@@ -60,7 +61,6 @@ if __name__ == "__main__":
         logger.info('You can find the log files for this run in {}'.format(logging_path))
         return logger
 
-
     if len(sys.argv) < 2:
         sys.exit('Expecting (relative) path to the parent directory of a problem file as argument. Use "battle --help" for more information on usage and options.')
 
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     parser.add_option('--do_not_count_points', dest='do_not_count_points', action='store_true', help='If set, points are not calculated for the run.')
     parser.add_option('--silent', dest='silent', action='store_true', help='Disable forking the logging output to stderr.')
     parser.add_option('--no-overhead-calculation', dest='no_overhead_calculation', action='store_true', help='If set, the program does not benchmark the I/O of the host system to calculate the runtime overhead when started.')
-    parser.add_option('--ui', dest='display_ui', action='store_true', help='If set, the program sets the --silent option and displays a small ui on STDOUT that shows the progess of the battles. Currently only works for iterated battles.')
+    parser.add_option('--ui', dest='display_ui', action='store_true', help='If set, the program sets the --silent option and displays a small ui on STDOUT that shows the progress of the battles. Currently only works for iterated battles.')
 
     (options, args) = parser.parse_args()
 
@@ -145,13 +145,13 @@ if __name__ == "__main__":
         ui = Ui()
         match.attach(ui)
 
-    results = match.run(options.battle_type, options.battle_rounds, options.iterated_cap, 
+    results = match.run(options.battle_type, options.battle_rounds, options.iterated_cap,
                         options.approximation_instance_size, options.approximation_iterations)
 
     if display_ui:
         match.detach(ui)
 
-    logger.info('#'*78)
+    logger.info('#' * 78)
     if not options.do_not_count_points:
         points = calculate_points(results, options.points)
 


### PR DESCRIPTION
Until now, the CI pipeline did linting and unittests in a single step.
These are now split into seperate steps, with a third step added for actual executions of the `battle` script.

The linting, which was done in two steps, is now unified in a single step and the linting rules were tightened. The files affected that did not fit the new format are updated.