### PR TITLE
Refactor match

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md
 include algobattle/config/*
 recursive-include algobattle/problems/delaytest/ **
 recursive-include algobattle/problems/testsproblem/ **
+recursive-include algobattle/battle_wrappers/ **

--- a/algobattle/battle_wrapper.py
+++ b/algobattle/battle_wrapper.py
@@ -16,8 +16,9 @@ class BattleWrapper(ABC):
 
     @abstractmethod
     def wrapper(self, match, options: dict) -> None:
-        """The main base method for a wrapper. In order to manage the
-        execution of a match, the wrapper needs the match object and possibly
+        """The main base method for a wrapper.
+
+        In order to manage the execution of a match, the wrapper needs the match object and possibly
         some options that are specific to the individual battle wrapper.
 
         A wrapper should update the match.match_data dict during its run by calling

--- a/algobattle/battle_wrapper.py
+++ b/algobattle/battle_wrapper.py
@@ -1,0 +1,37 @@
+"""Base class for wrappers that execute a specific kind of battle.
+
+The battle wrapper class is a base class for specific wrappers, which are
+responsible for executing specific types of battle. They share the
+characteristic that they are responsible for updating some match data during
+their run, such that it contains the current state of the match.
+"""
+import logging
+from abc import ABC, abstractmethod
+
+logger = logging.getLogger('algobattle.battle_wrapper')
+
+
+class BattleWrapper(ABC):
+    """Base class for wrappers that execute a specific kind of battle."""
+
+    @abstractmethod
+    def wrapper(self, match, options: dict) -> None:
+        """The main base method for a wrapper. In order to manage the
+        execution of a match, the wrapper needs the match object and possibly
+        some options that are specific to the individual battle wrapper.
+
+        A wrapper should update the match.match_data dict during its run by calling
+        the match.update_match_data method. This ensures that the callback
+        functionality around the match_data dict is properly executed.
+
+        It is assumed that the match.generating_team and match.solving_team are
+        set before calling a wrapper.
+
+        Parameters
+        ----------
+        match: Match
+            The Match object on which the battle wrapper is to be executed on.
+        options: dict
+            Additional options for the wrapper.
+        """
+        raise NotImplementedError

--- a/algobattle/battle_wrappers/averaged.py
+++ b/algobattle/battle_wrappers/averaged.py
@@ -1,3 +1,5 @@
+"""Wrapper that iterates the instance size up to a point where the solving team is no longer able to solve an instance."""
+
 import logging
 
 from algobattle.battle_wrapper import BattleWrapper
@@ -8,7 +10,7 @@ logger = logging.getLogger('algobattle.battle_wrappers.averaged')
 class Averaged(BattleWrapper):
     """Class of an adveraged battle Wrapper."""
 
-    def _averaged_battle_wrapper(self, match, options: dict = {}) -> None:
+    def wrapper(self, match, options: dict = {}) -> None:
         """Execute one averaged battle between a generating and a solving team.
 
         Execute several fights between two teams on a fixed instance size

--- a/algobattle/battle_wrappers/averaged.py
+++ b/algobattle/battle_wrappers/averaged.py
@@ -1,0 +1,39 @@
+import logging
+
+from algobattle.battle_wrapper import BattleWrapper
+
+logger = logging.getLogger('algobattle.battle_wrappers.averaged')
+
+
+class Averaged(BattleWrapper):
+    """Class of an adveraged battle Wrapper."""
+
+    def _averaged_battle_wrapper(self, match, options: dict = {}) -> None:
+        """Execute one averaged battle between a generating and a solving team.
+
+        Execute several fights between two teams on a fixed instance size
+        and determine the average solution quality.
+
+        During execution, this function updates the match_data of the match
+        object which is passed to it by
+        calls to the match.update_match_data function.
+
+        Parameters
+        ----------
+        match: Match
+            The Match object on which the battle wrapper is to be executed on.
+        options: dict
+            No additional options are used for this wrapper.
+        """
+        approximation_ratios = []
+        logger.info('==================== Averaged Battle, Instance Size: {}, Rounds: {} ===================='
+                    .format(match.match_data['approx_inst_size'], match.match_data['approx_iters']))
+        for i in range(match.match_data['approx_iters']):
+            logger.info('=============== Iteration: {}/{} ==============='.format(i + 1, match.match_data['approx_iters']))
+            approx_ratio = match._one_fight(instance_size=match.match_data['approx_inst_size'])
+            approximation_ratios.append(approx_ratio)
+
+            curr_pair = match.match_data['curr_pair']
+            curr_round = match.match_data[curr_pair]['curr_round']
+            match.update_match_data({curr_pair: {curr_round: {'approx_ratios':
+                                    match.match_data[curr_pair][curr_round]['approx_ratios'] + [approx_ratio]}}})

--- a/algobattle/battle_wrappers/iterated.py
+++ b/algobattle/battle_wrappers/iterated.py
@@ -1,3 +1,5 @@
+"""Wrapper that repeats a battle on an instance size a number of times and averages the competitive ratio over all runs."""
+
 import logging
 
 from algobattle.battle_wrapper import BattleWrapper

--- a/algobattle/battle_wrappers/iterated.py
+++ b/algobattle/battle_wrappers/iterated.py
@@ -1,0 +1,86 @@
+import logging
+
+from algobattle.battle_wrapper import BattleWrapper
+
+logger = logging.getLogger('algobattle.battle_wrappers.iterated')
+
+
+class Iterated(BattleWrapper):
+    """Class of an iterated battle Wrapper."""
+
+    def wrapper(self, match, options: dict = {'exponent': 2}) -> None:
+        """Execute one iterative battle between a generating and a solving team.
+
+        Incrementally try to search for the highest n for which the solver is
+        still able to solve instances.  The base increment value is multiplied
+        with the power of iterations since the last unsolvable instance to the
+        given exponent.
+        Only once the solver fails after the multiplier is reset, it counts as
+        failed. Since this would heavily favour probabilistic algorithms (That
+        may have only failed by chance and are able to solve a certain instance
+        size on a second try), we cap the maximum solution size by the first
+        value that an algorithm has failed on.
+
+        The wrapper automatically ends the battle and declares the solver as the
+        winner once the iteration cap is reached.
+
+        During execution, this function updates the match_data of the match
+        object which is passed to it by
+        calls to the match.update_match_data function.
+
+        Parameters
+        ----------
+        match: Match
+            The Match object on which the battle wrapper is to be executed on.
+        options: dict
+            A dict that contains an 'exponent' key with an int value of at least 1,
+            which determines the step size increase.
+        """
+        curr_pair = match.match_data['curr_pair']
+        curr_round = match.match_data[curr_pair]['curr_round']
+
+        n = match.problem.n_start
+        maximum_reached_n = 0
+        i = 0
+        exponent = options['exponent']
+        n_max = n_cap = match.match_data[curr_pair][curr_round]['cap']
+        alive = True
+
+        logger.info('==================== Iterative Battle, Instanze Size Cap: {} ===================='.format(n_cap))
+        while alive:
+            logger.info('=============== Instance Size: {}/{} ==============='.format(n, n_cap))
+            approx_ratio = match._one_fight(instance_size=n)
+            if approx_ratio == 0.0:
+                alive = False
+            elif approx_ratio > match.approximation_ratio:
+                logger.info('Solver {} does not meet the required solution quality at instance size {}. ({}/{})'
+                            .format(match.solving_team, n, approx_ratio, match.approximation_ratio))
+                alive = False
+
+            if not alive and i > 1:
+                # The step size increase was too aggressive, take it back and reset the increment multiplier
+                logger.info('Setting the solution cap to {}...'.format(n))
+                n_cap = n
+                n -= i ** exponent
+                i = 0
+                alive = True
+            elif n > maximum_reached_n and alive:
+                # We solved an instance of bigger size than before
+                maximum_reached_n = n
+
+            if n + 1 == n_cap:
+                alive = False
+            else:
+                i += 1
+                n += i ** exponent
+
+                if n >= n_cap and n_cap != n_max:
+                    # We have failed at this value of n already, reset the step size!
+                    n -= i ** exponent - 1
+                    i = 1
+                elif n >= n_cap and n_cap == n_max:
+                    logger.info('Solver {} exceeded the instance size cap of {}!'.format(match.solving_team, n_max))
+                    maximum_reached_n = n_max
+                    alive = False
+
+            match.update_match_data({curr_pair: {curr_round: {'cap': n_cap, 'solved': maximum_reached_n, 'attempting': n}}})

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -3,7 +3,7 @@ import subprocess
 
 import logging
 import configparser
-from typing import Callable, List
+from typing import Callable, List, Tuple
 
 import algobattle.sighandler as sigh
 from algobattle.team import Team
@@ -11,6 +11,8 @@ from algobattle.problem import Problem
 from algobattle.util import run_subprocess, update_nested_dict
 from algobattle.subject import Subject
 from algobattle.observer import Observer
+from algobattle.battle_wrappers.averaged import Averaged
+from algobattle.battle_wrappers.iterated import Iterated
 
 logger = logging.getLogger('algobattle.match')
 
@@ -19,6 +21,8 @@ class Match(Subject):
     """Match class, provides functionality for setting up and executing battles between given teams."""
 
     _observers: List[Observer] = []
+    generating_team = None
+    solving_team = None
 
     def __init__(self, problem: Problem, config_path: str, teams: list,
                  runtime_overhead=0, approximation_ratio=1.0, cache_docker_containers=True) -> None:
@@ -37,8 +41,6 @@ class Match(Subject):
         self.config = config
         self.approximation_ratio = approximation_ratio
 
-        self.generating_team = None
-        self.solving_team = None
         self.build_successful = self._build(teams, cache_docker_containers)
 
         if approximation_ratio != 1.0 and not problem.approximable:
@@ -54,19 +56,6 @@ class Match(Subject):
             "--memory=" + str(self.space_solver) + "mb",
             "--cpus=" + str(self.cpus)
         ]
-
-    def attach(self, observer: Observer) -> None:
-        """Subscribe a new Observer by adding them to the list of observers."""
-        self._observers.append(observer)
-
-    def detach(self, observer: Observer) -> None:
-        """Unsubscribe an Observer by removing them from the list of observers."""
-        self._observers.remove(observer)
-
-    def notify(self) -> None:
-        """Notify all subscribed Observers by calling their update() functions."""
-        for observer in self._observers:
-            observer.update(self)
 
     def build_successful(function: Callable) -> Callable:
         """Ensure that internal methods are only callable after a successful build."""
@@ -100,6 +89,32 @@ class Match(Subject):
                 return function(self, *args, **kwargs)
         return wrapper
 
+    def attach(self, observer: Observer) -> None:
+        """Subscribe a new Observer by adding them to the list of observers."""
+        self._observers.append(observer)
+
+    def detach(self, observer: Observer) -> None:
+        """Unsubscribe an Observer by removing them from the list of observers."""
+        self._observers.remove(observer)
+
+    def notify(self) -> None:
+        """Notify all subscribed Observers by calling their update() functions."""
+        for observer in self._observers:
+            observer.update(self)
+
+    @build_successful
+    def update_match_data(self, new_data: dict) -> bool:
+        """Update the internal match dict with new (partial) information.
+
+        Parameters
+        ----------
+        new_data : dict
+            A dict in the same format as match_data that contains new information.
+        """
+        self.match_data = update_nested_dict(self.match_data, new_data)
+        self.notify()
+        return True
+
     @docker_running
     def _build(self, teams: list, cache_docker_containers=True) -> bool:
         """Build docker containers for the given generators and solvers of each team.
@@ -129,7 +144,6 @@ class Match(Subject):
             return False
 
         self.team_names = [team.name for team in teams]
-        build_commands = []
         if len(self.team_names) != len(list(set(self.team_names))):
             logger.error('At least one team name is used twice!')
             return False
@@ -138,6 +152,7 @@ class Match(Subject):
         if len(teams) == 1:
             self.single_player = True
 
+        build_commands = []
         for team in teams:
             build_commands.append(base_build_command + ["solver-" + str(team.name), team.solver_path])
             build_commands.append(base_build_command + ["generator-" + str(team.name), team.generator_path])
@@ -235,10 +250,12 @@ class Match(Subject):
 
         battle_wrapper = None
 
+        options = dict()
         if battle_type == 'iterated':
-            battle_wrapper = self._iterated_battle_wrapper
+            battle_wrapper = Iterated()
+            options['exponent'] = 2
         elif battle_type == 'averaged':
-            battle_wrapper = self._averaged_battle_wrapper
+            battle_wrapper = Averaged()
         else:
             self.match_data['error'] = 'Unrecognized battle_type given: "{}"'.format(battle_type)
             logger.error(self.match_data['error'])
@@ -252,128 +269,16 @@ class Match(Subject):
 
                 self.generating_team = pair[0]
                 self.solving_team = pair[1]
-                _ = battle_wrapper()  # We currently update the match_data inside the wrappers
+                battle_wrapper.wrapper(self, options)
 
         return self.match_data
-
-    @build_successful
-    def update_match_data(self, new_data: dict) -> bool:
-        """Update the internal match dict with new (partial) information.
-
-        Parameters
-        ----------
-        new_data : dict
-            A dict in the same format as match_data that contains new information.
-        """
-        self.match_data = update_nested_dict(self.match_data, new_data)
-        self.notify()
-        return True
-
-    @build_successful
-    @team_roles_set
-    def _averaged_battle_wrapper(self) -> list:
-        """Execute one averaged battle between a generating and a solving team.
-
-        Execute several fights between two teams on a fixed instance size
-        and determine the average solution quality.
-
-        Returns
-        -------
-        list
-            Returns a list of the computed approximation ratios.
-        """
-        approximation_ratios = []
-        logger.info('==================== Averaged Battle, Instance Size: {}, Rounds: {} ===================='
-                    .format(self.match_data['approx_inst_size'], self.match_data['approx_iters']))
-        for i in range(self.match_data['approx_iters']):
-            logger.info('=============== Iteration: {}/{} ==============='.format(i + 1, self.match_data['approx_iters']))
-            approx_ratio = self._one_fight(instance_size=self.match_data['approx_inst_size'])
-            approximation_ratios.append(approx_ratio)
-
-            curr_pair = self.match_data['curr_pair']
-            curr_round = self.match_data[curr_pair]['curr_round']
-            self.update_match_data({curr_pair: {curr_round: {'approx_ratios':
-                                    self.match_data[curr_pair][curr_round]['approx_ratios'] + [approx_ratio]}}})
-
-        return approximation_ratios
-
-    @build_successful
-    @team_roles_set
-    def _iterated_battle_wrapper(self) -> int:
-        """Execute one iterative battle between a generating and a solving team.
-
-        Incrementally try to search for the highest n for which the solver is
-        still able to solve instances.  The base increment value is multiplied
-        with the square of the iterations since the last unsolvable instance.
-        Only once the solver fails after the multiplier is reset, it counts as
-        failed. Since this would heavily favour probabilistic algorithms (That
-        may have only failed by chance and are able to solve a certain instance
-        size on a second try), we cap the maximum solution size by the first
-        value that an algorithm has failed on.
-
-        The wrapper automatically ends the battle and declares the solver as the
-        winner once the iteration cap is reached, which is set in the config.ini.
-
-        Returns
-        -------
-        int
-            Returns the biggest instance size for which the solving team still
-            found a solution.
-        """
-        curr_pair = self.match_data['curr_pair']
-        curr_round = self.match_data[curr_pair]['curr_round']
-
-        n = self.problem.n_start
-        maximum_reached_n = 0
-        i = 0
-        n_max = n_cap = self.match_data[curr_pair][curr_round]['cap']
-        alive = True
-
-        logger.info('==================== Iterative Battle, Instanze Size Cap: {} ===================='.format(n_cap))
-        while alive:
-            logger.info('=============== Instance Size: {}/{} ==============='.format(n, n_cap))
-            approx_ratio = self._one_fight(instance_size=n)
-            if approx_ratio == 0.0:
-                alive = False
-            elif approx_ratio > self.approximation_ratio:
-                logger.info('Solver {} does not meet the required solution quality at instance size {}. ({}/{})'
-                            .format(self.solving_team, n, approx_ratio, self.approximation_ratio))
-                alive = False
-
-            if not alive and i > 1:
-                # The step size increase was too aggressive, take it back and reset the increment multiplier
-                logger.info('Setting the solution cap to {}...'.format(n))
-                n_cap = n
-                n -= i * i
-                i = 0
-                alive = True
-            elif n > maximum_reached_n and alive:
-                # We solved an instance of bigger size than before
-                maximum_reached_n = n
-
-            if n + 1 == n_cap:
-                alive = False
-            else:
-                i += 1
-                n += i * i
-
-                if n >= n_cap and n_cap != n_max:
-                    # We have failed at this value of n already, reset the step size!
-                    n -= i * i - 1
-                    i = 1
-                elif n >= n_cap and n_cap == n_max:
-                    logger.info('Solver {} exceeded the instance size cap of {}!'.format(self.solving_team, n_max))
-                    maximum_reached_n = n_max
-                    alive = False
-
-            self.update_match_data({curr_pair: {curr_round: {'cap': n_cap, 'solved': maximum_reached_n, 'attempting': n}}})
-        return maximum_reached_n
 
     @docker_running
     @build_successful
     @team_roles_set
     def _one_fight(self, instance_size: int) -> float:
-        """Execute a single fight of a battle between a given generator and solver for a given instance size.
+        """Execute a single fight of a battle between a given generator and
+        solver for a given instance size.
 
         Parameters
         ----------
@@ -387,25 +292,55 @@ class Match(Subject):
             the generator (1 if optimal, 0 if failed, >=1 if the
             generator solution is optimal).
         """
-        if not isinstance(instance_size, int) or not instance_size > 0:
-            logger.error('Expected an instance size to be an int of size at least 1, received: {}'.format(instance_size))
-            raise Exception('Expected the instance size to be a positive integer.')
+        instance, generator_solution = self._run_generator(instance_size)
 
+        if not instance and not generator_solution:
+            return 1.0
+
+        solver_solution = self._run_solver(instance_size, instance)
+
+        if not solver_solution:
+            return 0.0
+
+        approximation_ratio = self.problem.verifier.calculate_approximation_ratio(instance, instance_size,
+                                                                                  generator_solution, solver_solution)
+        logger.info('Solver of group {} yields a valid solution with an approx. ratio of {} at instance size {}.'
+                    .format(self.solving_team, approximation_ratio, instance_size))
+        return approximation_ratio
+
+    @docker_running
+    @build_successful
+    @team_roles_set
+    def _run_generator(self, instance_size: int) -> Tuple[any, any]:
+        """Execute the generator of match.generating_team and check the
+        validity of the generated output. If the validity checks pass,
+        return the instance and the certificate solution.
+
+        Parameters
+        ----------
+        instance_size : int
+            The instance size, expected to be a positive int.
+
+        Returns
+        -------
+        any, any
+            If the validity checks pass, the (instance, solution) in whatever
+            format that is specified, else (None, None).
+        """
         generator_run_command = self.base_run_command + ["generator-" + str(self.generating_team)]
-        solver_run_command    = self.base_run_command + ["solver-"    + str(self.solving_team)]
 
-        logger.info('Running generator of group {}...\n'.format(self.generating_team))
+        logger.debug('Running generator of group {}...\n'.format(self.generating_team))
 
         sigh.latest_running_docker_image = "generator-" + str(self.generating_team)
         encoded_output, _ = run_subprocess(generator_run_command, str(instance_size).encode(),
                                            self.timeout_generator)
         if not encoded_output:
             logger.warning('No output was generated when running the generator!')
-            return 1.0
+            return None, None
 
         raw_instance_with_solution = self.problem.parser.decode(encoded_output)
 
-        logger.info('Checking generated instance and certificate...')
+        logger.debug('Checking generated instance and certificate...')
 
         raw_instance, raw_solution = self.problem.parser.split_into_instance_and_solution(raw_instance_with_solution)
         instance                   = self.problem.parser.parse_instance(raw_instance, instance_size)
@@ -414,45 +349,63 @@ class Match(Subject):
         if not self.problem.verifier.verify_semantics_of_instance(instance, instance_size):
             logger.warning('Generator {} created a malformed instance at instance size {}!'
                            .format(self.generating_team, instance_size))
-            return 1.0
+            return None, None
 
         if not self.problem.verifier.verify_semantics_of_solution(generator_solution, instance_size, True):
             logger.warning('Generator {} created a malformed solution at instance size {}!'
                            .format(self.generating_team, instance_size))
-            return 1.0
+            return None, None
 
         if not self.problem.verifier.verify_solution_against_instance(instance, generator_solution, instance_size, True):
             logger.warning('Generator {} failed at instance size {} due to a wrong certificate for its generated instance!'
                            .format(self.generating_team, instance_size))
-            return 1.0
+            return None, None
 
-        logger.info('Generated instance and certificate are valid!\n\n')
+        logger.info('Generated instance and certificate by group {} are valid!\n'.format(self.generating_team))
 
-        logger.info('Running solver of group {}...\n'.format(self.solving_team))
+        return instance, generator_solution
+
+    @docker_running
+    @build_successful
+    @team_roles_set
+    def _run_solver(self, instance_size: int, instance: any) -> any:
+        """Execute the solver of match.solving_team and check the
+        validity of the generated output. If the validity checks pass,
+        return the solver solution.
+
+        Parameters
+        ----------
+        instance_size : int
+            The instance size, expected to be a positive int.
+
+        Returns
+        -------
+        any
+            If the validity checks pass, solution in whatever
+            format that is specified, else None.
+        """
+        solver_run_command = self.base_run_command + ["solver-" + str(self.solving_team)]
+        logger.debug('Running solver of group {}...\n'.format(self.solving_team))
 
         sigh.latest_running_docker_image = "solver-" + str(self.solving_team)
         encoded_output, _ = run_subprocess(solver_run_command, self.problem.parser.encode(instance),
                                            self.timeout_solver)
         if not encoded_output:
             logger.warning('No output was generated when running the solver!')
-            return 0.0
+            return None
 
         raw_solver_solution = self.problem.parser.decode(encoded_output)
 
-        logger.info('Checking validity of the solvers solution...')
+        logger.debug('Checking validity of the solvers solution...')
 
         solver_solution = self.problem.parser.parse_solution(raw_solver_solution, instance_size)
         if not self.problem.verifier.verify_semantics_of_solution(solver_solution, instance_size, True):
-            logger.warning('Solver {} created a malformed solution at instance size {}!'
+            logger.warning('Solver of group {} created a malformed solution at instance size {}!'
                            .format(self.solving_team, instance_size))
-            return 0.0
+            return None
         elif not self.problem.verifier.verify_solution_against_instance(instance, solver_solution, instance_size, False):
-            logger.warning('Solver {} yields a wrong solution at instance size {}!'
+            logger.warning('Solver of group {} yields a wrong solution at instance size {}!'
                            .format(self.solving_team, instance_size))
-            return 0.0
-        else:
-            approximation_ratio = self.problem.verifier.calculate_approximation_ratio(instance, instance_size,
-                                                                                      generator_solution, solver_solution)
-            logger.info('Solver {} yields a valid solution with an approx. ratio of {} at instance size {}.'
-                        .format(self.solving_team, approximation_ratio, instance_size))
-            return approximation_ratio
+            return None
+
+        return solver_solution

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -277,8 +277,7 @@ class Match(Subject):
     @build_successful
     @team_roles_set
     def _one_fight(self, instance_size: int) -> float:
-        """Execute a single fight of a battle between a given generator and
-        solver for a given instance size.
+        """Execute a single fight of a battle between a given generator and solver for a given instance size.
 
         Parameters
         ----------
@@ -312,9 +311,9 @@ class Match(Subject):
     @build_successful
     @team_roles_set
     def _run_generator(self, instance_size: int) -> Tuple[any, any]:
-        """Execute the generator of match.generating_team and check the
-        validity of the generated output. If the validity checks pass,
-        return the instance and the certificate solution.
+        """Execute the generator of match.generating_team and check the validity of the generated output.
+
+        If the validity checks pass, return the instance and the certificate solution.
 
         Parameters
         ----------
@@ -369,9 +368,9 @@ class Match(Subject):
     @build_successful
     @team_roles_set
     def _run_solver(self, instance_size: int, instance: any) -> any:
-        """Execute the solver of match.solving_team and check the
-        validity of the generated output. If the validity checks pass,
-        return the solver solution.
+        """Execute the solver of match.solving_team and check the validity of the generated output.
+
+        If the validity checks pass, return the solver solution.
 
         Parameters
         ----------

--- a/scripts/battle
+++ b/scripts/battle
@@ -45,7 +45,10 @@ if __name__ == "__main__":
         current_timestamp = '{:04d}-{:02d}-{:02d}_{:02d}:{:02d}:{:02d}'.format(_now.year, _now.month, _now.day, _now.hour, _now.minute, _now.second)
         logging_path = logging_path + current_timestamp + '.log'
 
-        logging.basicConfig(filename=logging_path, level=common_logging_level, format='%(asctime)s %(levelname)s: %(message)s', datefmt='%H:%M:%S')
+        logging.basicConfig(handlers=[logging.FileHandler(logging_path, 'w', 'utf-8')],
+                            level=common_logging_level,
+                            format='%(asctime)s %(levelname)s: %(message)s',
+                            datefmt='%H:%M:%S')
 
         logger = logging.getLogger('algobattle')
 


### PR DESCRIPTION
Split up the `match._one_fight` method into two methods, one for the generator and one for the solver.

Move the battle wrappers from `match.py` into separate files with a new abstract base class on top. This should make the wrappers much more modular and make it easier to implement and test new wrappers.