### PR TITLE
Feature: memory scaler

### DIFF
--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -47,13 +47,23 @@ class Match(Subject):
             logger.error('The given problem is not approximable and can only be run with an approximation ratio of 1.0!')
             self.build_successful = False
 
-        self.base_run_command = [
+        self.generator_base_run_command = lambda a: [
             "docker",
             "run",
             "--rm",
             "--network", "none",
             "-i",
-            "--memory=" + str(self.space_solver) + "mb",
+            "--memory=" + str(a) + "mb",
+            "--cpus=" + str(self.cpus)
+        ]
+
+        self.solver_base_run_command = lambda a: [
+            "docker",
+            "run",
+            "--rm",
+            "--network", "none",
+            "-i",
+            "--memory=" + str(a) + "mb",
             "--cpus=" + str(self.cpus)
         ]
 
@@ -303,8 +313,8 @@ class Match(Subject):
 
         approximation_ratio = self.problem.verifier.calculate_approximation_ratio(instance, instance_size,
                                                                                   generator_solution, solver_solution)
-        logger.info('Solver of group {} yields a valid solution with an approx. ratio of {} at instance size {}.'
-                    .format(self.solving_team, approximation_ratio, instance_size))
+        logger.info('Solver of group {} yields a valid solution with an approx. ratio of {}.'
+                    .format(self.solving_team, approximation_ratio))
         return approximation_ratio
 
     @docker_running
@@ -326,7 +336,8 @@ class Match(Subject):
             If the validity checks pass, the (instance, solution) in whatever
             format that is specified, else (None, None).
         """
-        generator_run_command = self.base_run_command + ["generator-" + str(self.generating_team)]
+        scaled_memory = self.problem.generator_memory_scaler(self.space_generator, instance_size)
+        generator_run_command = self.generator_base_run_command(scaled_memory) + ["generator-" + str(self.generating_team)]
 
         logger.debug('Running generator of group {}...\n'.format(self.generating_team))
 
@@ -334,7 +345,7 @@ class Match(Subject):
         encoded_output, _ = run_subprocess(generator_run_command, str(instance_size).encode(),
                                            self.timeout_generator)
         if not encoded_output:
-            logger.warning('No output was generated when running the generator!')
+            logger.warning('No output was generated when running the generator group {}!'.format(self.generating_team))
             return None, None
 
         raw_instance_with_solution = self.problem.parser.decode(encoded_output)
@@ -346,18 +357,16 @@ class Match(Subject):
         generator_solution         = self.problem.parser.parse_solution(raw_solution, instance_size)
 
         if not self.problem.verifier.verify_semantics_of_instance(instance, instance_size):
-            logger.warning('Generator {} created a malformed instance at instance size {}!'
-                           .format(self.generating_team, instance_size))
+            logger.warning('Generator {} created a malformed instance!'.format(self.generating_team))
             return None, None
 
         if not self.problem.verifier.verify_semantics_of_solution(generator_solution, instance_size, True):
-            logger.warning('Generator {} created a malformed solution at instance size {}!'
-                           .format(self.generating_team, instance_size))
+            logger.warning('Generator {} created a malformed solution at instance size!'.format(self.generating_team))
             return None, None
 
         if not self.problem.verifier.verify_solution_against_instance(instance, generator_solution, instance_size, True):
-            logger.warning('Generator {} failed at instance size {} due to a wrong certificate for its generated instance!'
-                           .format(self.generating_team, instance_size))
+            logger.warning('Generator {} failed due to a wrong certificate for its generated instance!'
+                           .format(self.generating_team))
             return None, None
 
         logger.info('Generated instance and certificate by group {} are valid!\n'.format(self.generating_team))
@@ -383,14 +392,15 @@ class Match(Subject):
             If the validity checks pass, solution in whatever
             format that is specified, else None.
         """
-        solver_run_command = self.base_run_command + ["solver-" + str(self.solving_team)]
+        scaled_memory = self.problem.solver_memory_scaler(self.space_solver, instance_size)
+        solver_run_command = self.solver_base_run_command(scaled_memory) + ["solver-" + str(self.solving_team)]
         logger.debug('Running solver of group {}...\n'.format(self.solving_team))
 
         sigh.latest_running_docker_image = "solver-" + str(self.solving_team)
         encoded_output, _ = run_subprocess(solver_run_command, self.problem.parser.encode(instance),
                                            self.timeout_solver)
         if not encoded_output:
-            logger.warning('No output was generated when running the solver!')
+            logger.warning('No output was generated when running the solver of group {}!'.format(self.solving_team))
             return None
 
         raw_solver_solution = self.problem.parser.decode(encoded_output)

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -40,5 +40,13 @@ class Problem(metaclass=ABCMeta):
         """Boolean flag indicating whether a problem can have an approximate solution."""
         raise NotImplementedError
 
+    def generator_memory_scaler(self, memory, instance_size):
+        """Method that scales the amount of memory of the generator in relation to the given instance size."""
+        return memory
+
+    def solver_memory_scaler(self, memory, instance_size):
+        """Method that scales the amount of memory of the solver in relation to the given instance size."""
+        return memory
+
     def __str__(self) -> str:
         return self.name

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -63,7 +63,7 @@ def measure_runtime_overhead() -> float:
     overheads = []
     for i in range(5):
         sigh.latest_running_docker_image = "generator0"
-        _, timeout = run_subprocess(match.base_run_command + ["generator0"],
+        _, timeout = run_subprocess(match.generator_base_run_command(match.space_generator) + ["generator0"],
                                     input=str(50 * i).encode(), timeout=match.timeout_generator)
         if not timeout:
             timeout = match.timeout_generator

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -70,8 +70,8 @@ class Utiltests(unittest.TestCase):
 
     def test_run_subprocess(self):
         team = Team('0', self.tests_path + '/generator_timeout', self.tests_path + '/solver')
-        match_run_timeout = Match(self.problem, self.config, [team])
-        raw_output, _ = run_subprocess(match_run_timeout.base_run_command + ['generator-0'], 0, 2)
+        match = Match(self.problem, self.config, [team])
+        raw_output, _ = run_subprocess(match.generator_base_run_command(match.space_generator) + ['generator-0'], 0, 2)
         self.assertIsNone(raw_output)
 
 


### PR DESCRIPTION
This pull request introduces the possibility to scale the available memory of a problem to the current instance size of a problem. By default, the memory given in the config file used for the run is used for every instance size.

You can overwrite the `generator_memory_scaler` and `solver_memory_scaler` in the `problem.py` of a concrete problem to overwrite the memory usage.  Both methods are expected to have `memory` and `instance_size` as arguments. 