### PR TITLE
Fix #22 by increasing the build timeout time for delaytest

### DIFF
--- a/algobattle/config/config_delaytest.ini
+++ b/algobattle/config/config_delaytest.ini
@@ -1,7 +1,7 @@
 #Please do not change the values in this config file.
 [run_parameters]
 # Time for building the docker container (in seconds)
-timeout_build           = 30
+timeout_build           = 300
 # Runtime cap for the generator (in seconds)
 timeout_generator       = 300
 # Runtime cap for the solver (in seconds)


### PR DESCRIPTION
The delaytest time was increased to the same time as for building the generator of the delaytest problem. This should be sufficient time for the initial build.