### PR TITLE
Fix #42 by adding previously missing newline after carriage returns

### DIFF
--- a/algobattle/battle_wrappers/averaged.py
+++ b/algobattle/battle_wrappers/averaged.py
@@ -152,8 +152,8 @@ class Averaged(BattleWrapper):
                                            + '║{:>6.2f}║{:>6d}║{:>3d}/{:>3d} ║'.format(latest_approx_ratio,
                                                                                        match_data['approx_inst_size'],
                                                                                        curr_iter,
-                                                                                       match_data['approx_iters']) + '\r'
-        formatted_output_string += '\n╚═════════╩═════════╩' \
+                                                                                       match_data['approx_iters']) + '\r\n'
+        formatted_output_string += '╚═════════╩═════════╩' \
                                    + ''.join(['══════╩' for i in range(match_data['rounds'])]) \
                                    + '══════╩══════╩════════╝' + '\n\r'
 

--- a/algobattle/battle_wrappers/iterated.py
+++ b/algobattle/battle_wrappers/iterated.py
@@ -173,8 +173,8 @@ class Iterated(BattleWrapper):
                 formatted_output_string += '║{:>9s}║{:>9s}'.format(pair[0], pair[1]) \
                                            + ''.join(['║{:>6d}'.format(match_data[pair][i]['solved'])
                                                      for i in range(match_data['rounds'])]) \
-                                           + '║{:>6d}║{:>6d}║'.format(match_data[pair][curr_round]['cap'], avg) + '\r'
-        formatted_output_string += '\n╚═════════╩═════════╩' \
+                                           + '║{:>6d}║{:>6d}║'.format(match_data[pair][curr_round]['cap'], avg) + '\r\n'
+        formatted_output_string += '╚═════════╩═════════╩' \
                                    + ''.join(['══════╩' for i in range(match_data['rounds'])]) \
                                    + '══════╩══════╝' + '\n\r'
 


### PR DESCRIPTION
While every pairing of teams was output by the `format_as_utf8` methods of the battle_wrappers, a carriage return without a newline was written out at the end of each such line. Thus, every line overwrote the previous one, making it seem like the UI was frozen until the last fight was executed.