### PR TITLE
remove rounding of result display

### DIFF
--- a/algobattle/battle_wrappers/averaged.py
+++ b/algobattle/battle_wrappers/averaged.py
@@ -141,7 +141,7 @@ class Averaged(BattleWrapper):
                     n_dead_iters = executed_iters - len([i for i in match_data[pair][i]['approx_ratios'] if i != 0.0])
 
                     if executed_iters - n_dead_iters > 0:
-                        avg[i] = sum(match_data[pair][i]['approx_ratios']) // (executed_iters - n_dead_iters)
+                        avg[i] = sum(match_data[pair][i]['approx_ratios']) / (executed_iters - n_dead_iters)
 
                 curr_round = match_data[pair]['curr_round']
                 curr_iter = len(match_data[pair][curr_round]['approx_ratios'])


### PR DESCRIPTION
Small bugfix to have the ui display of the averaged battle results be shown properly. Currently they are being formatted as floats, but the calculation already rounds them beforehand, which can lead to weird looking results when e.g. one team gets an approx. ratio of 1.9 and the other one of 1. The points will be divided in an almost 2 to 1 split but the display summary looks even.

And this isn't really a bug, but while looking at this I also noticed that line 157 ( and 176 of the iterated wrapper) appends `\r\n` line endings, which are probably not intended over `\n`?