### PR TITLE
Cross platform support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,7 @@ name: Algorithmic Battle
 
 on:
   push:
-    branches: [ main, develop, 4.0.0-rc, cross_platform ]
+    branches: [ main, develop, 4.0.0-rc ]
   pull_request:
     branches: [ main, develop, 4.0.0-rc ]
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,8 +43,9 @@ jobs:
     - name: get fake alpine image for tests
       if: runner.os == 'Windows'
       run: |
-        docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
-        docker image tag mcr.microsoft.com/windows/nanoserver:ltsc2022 alpine
+        docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022 &
+        docker image tag mcr.microsoft.com/windows/nanoserver:ltsc2022 alpine &
+        docker images
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,6 +40,11 @@ jobs:
     - name: install Docker
       if: runner.os == 'macOS'
       uses: docker-practice/actions-setup-docker@master
+    - name: get fake alpine image for tests
+      if: runner.os == 'Windows'
+      run: |
+        docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
+        docker image tag mcr.microsoft.com/windows/nanoserver:ltsc2022 alpine
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -62,6 +67,11 @@ jobs:
     - name: install Docker
       if: runner.os == 'macOS'
       uses: docker-practice/actions-setup-docker@master
+    - name: get fake alpine image for tests
+      if: runner.os == 'Windows'
+      run: |
+        docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
+        docker image tag mcr.microsoft.com/windows/nanoserver:ltsc2022 alpine
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -63,9 +63,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
-    - name: install Docker
-      if: runner.os == 'macOS'
-      uses: docker-practice/actions-setup-docker@master
     - name: get fake alpine image for tests
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,9 +43,7 @@ jobs:
     - name: get fake alpine image for tests
       if: runner.os == 'Windows'
       run: |
-        docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022 &
-        docker image tag mcr.microsoft.com/windows/nanoserver:ltsc2022 alpine &
-        docker images
+        docker image tag mcr.microsoft.com/windows/servercore:ltsc2022 alpine
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,7 @@ name: Algorithmic Battle
 
 on:
   push:
-    branches: [ main, develop, 4.0.0-rc ]
+    branches: [ main, develop, 4.0.0-rc, cross_platform ]
   pull_request:
     branches: [ main, develop, 4.0.0-rc ]
 
@@ -26,7 +26,11 @@ jobs:
       run: flake8 .
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -41,7 +45,11 @@ jobs:
       run: python -m unittest --failfast
 
   execute:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,6 +37,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
+    - name: install Docker
+      if: runner.os == 'macOS'
+      uses: docker-practice/actions-setup-docker@master
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -56,6 +59,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
+    - name: install Docker
+      if: runner.os == 'macOS'
+      uses: docker-practice/actions-setup-docker@master
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -69,8 +69,7 @@ jobs:
     - name: get fake alpine image for tests
       if: runner.os == 'Windows'
       run: |
-        docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
-        docker image tag mcr.microsoft.com/windows/nanoserver:ltsc2022 alpine
+        docker image tag mcr.microsoft.com/windows/servercore:ltsc2022 alpine
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Points are distributed relative to the biggest instance size for which a group
 was still able to solve an instance.
 
 # Installation
-This project has been delevoped to run on Linux and may not work on other
-platforms. Support for other platforms may be implemented in the future.
+This project is being developed to run on all major operating systems (Windows, MacOS, and Linux).
 
 `python3` in version at least `3.10` and `docker` are required.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Points are distributed relative to the biggest instance size for which a group
 was still able to solve an instance.
 
 # Installation
-This project is being developed to run on all major operating systems (Windows, MacOS, and Linux).
+This project is being developed and tested on both Windows and Linux, MacOS support
+is being worked on but still is tentative.
 
 `python3` in version at least `3.10` and `docker` are required.
 

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -1,6 +1,5 @@
 """Main battle script. Executes all possible types of battles, see battle --help for all options."""
 import sys
-import os
 import logging
 import datetime as dt
 
@@ -43,8 +42,7 @@ def setup_logging(logging_path: Path, verbose_logging: bool, silent: bool):
     Path(logging_path).mkdir(exist_ok=True)
 
     t = dt.datetime.now()
-    sep = ':' if os.name == 'posix' else '-'
-    current_timestamp = f"{t.year:04d}-{t.month:02d}-{t.day:02d}_{t.hour:02d}{sep}{t.minute:02d}{sep}{t.second:02d}"
+    current_timestamp = f"{t.year:04d}-{t.month:02d}-{t.day:02d}_{t.hour:02d}-{t.minute:02d}-{t.second:02d}"
     logging_path = Path(logging_path, current_timestamp + '.log')
 
     logging.basicConfig(handlers=[logging.FileHandler(logging_path, 'w', 'utf-8')],

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -181,6 +181,8 @@ class Image:
                 sleep(0.01)
             elapsed_time = round(default_timer() - start_time, 2)
 
+            if exit_code := cast(dict, container.attrs)["State"]["ExitCode"] != 0:
+                raise DockerError(f"{self.description} exited with error code: {exit_code}")
             output_iter, _stat = container.get_archive("output")
             output = extract(b"".join(output_iter), "output")
 

--- a/algobattle/problems/testsproblem/generator/Dockerfile
+++ b/algobattle/problems/testsproblem/generator/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static instance and certificate
 COPY output /output
-ENTRYPOINT ["true"]
+ENTRYPOINT ["echo", "1"]

--- a/algobattle/problems/testsproblem/generator/Dockerfile
+++ b/algobattle/problems/testsproblem/generator/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static instance and certificate
 COPY output /output
-ENTRYPOINT ["echo", "1"]
+ENTRYPOINT echo 1

--- a/algobattle/problems/testsproblem/generator_build_timeout/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_build_timeout/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine
 
-RUN sleep 6000;
+RUN sleep 6000

--- a/algobattle/problems/testsproblem/generator_execution_error/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_execution_error/Dockerfile
@@ -1,5 +1,4 @@
-FROM scratch
+FROM alpine
 
 # causes an error on container execution
-# the actual command here is irrelevant since scratch doesn't include a shell so it will always throw an error
 ENTRYPOINT exit 1

--- a/algobattle/problems/testsproblem/generator_execution_error/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_execution_error/Dockerfile
@@ -2,4 +2,4 @@ FROM scratch
 
 # causes an error on container execution
 # the actual command here is irrelevant since scratch doesn't include a shell so it will always throw an error
-CMD ["exit", "1"]
+ENTRYPOINT exit 1

--- a/algobattle/problems/testsproblem/generator_malformed_solution/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_malformed_solution/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, artificially malformed solution.
 COPY output /output
-ENTRYPOINT ["true"]
+ENTRYPOINT ["echo", "1"]

--- a/algobattle/problems/testsproblem/generator_malformed_solution/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_malformed_solution/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, artificially malformed solution.
 COPY output /output
-ENTRYPOINT ["echo", "1"]
+ENTRYPOINT echo 1

--- a/algobattle/problems/testsproblem/generator_timeout/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_timeout/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine
 
 # causes an execution timeout.
-CMD ["sleep", "1000000"]
+CMD sleep 6000

--- a/algobattle/problems/testsproblem/generator_wrong_certificate/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_wrong_certificate/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static string encoding an instance with an artificially wrong certificate.
 COPY output /output
-ENTRYPOINT ["true"]
+ENTRYPOINT ["echo", "1"]

--- a/algobattle/problems/testsproblem/generator_wrong_certificate/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_wrong_certificate/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static string encoding an instance with an artificially wrong certificate.
 COPY output /output
-ENTRYPOINT ["echo", "1"]
+ENTRYPOINT echo 1

--- a/algobattle/problems/testsproblem/generator_wrong_instance/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_wrong_instance/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a semantically wrong instance.
 COPY output /output
-ENTRYPOINT ["echo", "1"]
+ENTRYPOINT echo 1

--- a/algobattle/problems/testsproblem/generator_wrong_instance/Dockerfile
+++ b/algobattle/problems/testsproblem/generator_wrong_instance/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a semantically wrong instance.
 COPY output /output
-ENTRYPOINT ["true"]
+ENTRYPOINT ["echo", "1"]

--- a/algobattle/problems/testsproblem/solver/Dockerfile
+++ b/algobattle/problems/testsproblem/solver/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static solution.
 COPY output /output
-ENTRYPOINT ["echo", "1"]
+ENTRYPOINT echo 1

--- a/algobattle/problems/testsproblem/solver/Dockerfile
+++ b/algobattle/problems/testsproblem/solver/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static solution.
 COPY output /output
-ENTRYPOINT ["true"]
+ENTRYPOINT ["echo", "1"]

--- a/algobattle/problems/testsproblem/solver_execution_error/Dockerfile
+++ b/algobattle/problems/testsproblem/solver_execution_error/Dockerfile
@@ -1,5 +1,4 @@
-FROM scratch
+FROM alpine
 
 # causes an error on container execution
-# the actual command here is irrelevant since scratch doesn't include a shell so it will always throw an error
 ENTRYPOINT exit 1

--- a/algobattle/problems/testsproblem/solver_execution_error/Dockerfile
+++ b/algobattle/problems/testsproblem/solver_execution_error/Dockerfile
@@ -2,4 +2,4 @@ FROM scratch
 
 # causes an error on container execution
 # the actual command here is irrelevant since scratch doesn't include a shell so it will always throw an error
-CMD ["exit", "1"]
+ENTRYPOINT exit 1

--- a/algobattle/problems/testsproblem/solver_malformed_solution/Dockerfile
+++ b/algobattle/problems/testsproblem/solver_malformed_solution/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, semantically wrong solution.
 COPY output /output
-ENTRYPOINT ["true"]
+ENTRYPOINT ["echo", "1"]

--- a/algobattle/problems/testsproblem/solver_malformed_solution/Dockerfile
+++ b/algobattle/problems/testsproblem/solver_malformed_solution/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, semantically wrong solution.
 COPY output /output
-ENTRYPOINT ["echo", "1"]
+ENTRYPOINT echo 1

--- a/algobattle/problems/testsproblem/solver_timeout/Dockerfile
+++ b/algobattle/problems/testsproblem/solver_timeout/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine
 
 # causes an execution timeout.
-CMD ["sleep", "1000000"]
+ENTRYPOINT sleep 6000

--- a/algobattle/problems/testsproblem/solver_wrong_certificate/Dockerfile
+++ b/algobattle/problems/testsproblem/solver_wrong_certificate/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, artificially wrong solution.
 COPY output /output
-ENTRYPOINT ["true"]
+ENTRYPOINT ["echo", "1"]

--- a/algobattle/problems/testsproblem/solver_wrong_certificate/Dockerfile
+++ b/algobattle/problems/testsproblem/solver_wrong_certificate/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, artificially wrong solution.
 COPY output /output
-ENTRYPOINT ["echo", "1"]
+ENTRYPOINT echo 1

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -60,7 +60,6 @@ class DockerTests(unittest.TestCase):
                 image.run(timeout=10.0)
             finally:
                 image.remove()
-                raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
addressing #50 this PR adds CI checks for windows and macOS. It also includes 2 very minor bugfixes that I noticed because of the more extensive testing.

There were two big problems when making this that will also impact future work:
1. The github macOS VMs don't come with a docker daemon preinstalled, apparently because of licensing issues. This means that we need to install it ourselves every time tests are run, which takes about ten minutes. I'm working on another PR that adds more tests that will also include tests for the whole battle script, so we'll then only have to install it once.
2. The github windows VMs have the docker daemon run in windows container mode, apparently due to VM nesting issues. Because of that we can't run any linux images in our tests. I think the "proper" solution here would be to have multiple dockerfiles for each test and have the testing framework choose the right one based on the os. But since our testing docker images are so simple (either doing a no op, raising an error, or sleeping for a long time) I decided to just make all dockerfiles work on both OSes. Because of that we need to use the shell form of the entrypoint (`ENTRYPOINT sleep 10` rather than `ENTRYPOINT ["sleep", "10"]`) and alias a windows image to 'alpine'.

Currently the tests running the whole script fail on macOS. From what I can tell this is not because of an actual OS issue or bug in our code but because installing scripts works differently than on linux/windows. I have no experience with that and can't find anything related to that on google so I'm just leaving it as is.