### PR TITLE
Isolate docker build environments

### DIFF
--- a/algobattle/__init__.py
+++ b/algobattle/__init__.py
@@ -1,4 +1,4 @@
 __title__ = 'Algorithmic Battle'
-__version__ = '3.0.2'
+__version__ = '3.1.0'
 __author__ = 'Jan Dreier, Henri Lotze'
 __license__ = 'MIT'

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -5,6 +5,7 @@ import os
 
 import logging
 import configparser
+from time import sleep
 from typing import Callable, List, Tuple
 
 import algobattle.sighandler as sigh
@@ -204,13 +205,13 @@ class Match(Subject):
                         image_archives.pop().unlink()
                     break
                 else:
-                    path = command[-1].parent / f"{command[-2]}-archive.tar"
-                    subprocess.Popen(["docker", "save", command[-2], "-o", path], stdout=subprocess.PIPE)
+                    path = Path(command[-1]) / f"{command[-2]}-archive.tar"
+                    subprocess.run(["docker", "save", command[-2], "-o", str(path)], stdout=subprocess.PIPE)
                     image_archives.append(path)
-                    subprocess.Popen(["docker", "image", "rm", "-f", command[-2]])
+                    subprocess.run(["docker", "image", "rm", "-f", command[-2]], stdout=subprocess.PIPE)
 
         for path in image_archives:
-            subprocess.Popen(["docker", "load", "-q", "-i", str(path)])
+            subprocess.run(["docker", "load", "-q", "-i", str(path)], stdout=subprocess.PIPE)
             path.unlink()
         return len(self.team_names) > 0
 
@@ -311,7 +312,7 @@ class Match(Subject):
 
         for team in self.team_names:
             for role in ("generator", "solver"):
-                    subprocess.Popen(["docker", "image", "rm", "-f", f"{role}-{team}"])
+                    subprocess.run(["docker", "image", "rm", "-f", f"{role}-{team}"], stdout=subprocess.PIPE)
         return self.match_data
 
     @docker_running

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -34,6 +34,8 @@ class Match(Subject):
 
         if os.name != 'posix':
             self.creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            self.creation_flags = 0
 
         config = configparser.ConfigParser()
         logger.debug('Using additional configuration options from file "%s".', config_path)

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -5,7 +5,6 @@ import os
 
 import logging
 import configparser
-from time import sleep
 from typing import Callable, List, Tuple
 
 import algobattle.sighandler as sigh

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -176,7 +176,7 @@ class Match(Subject):
 
         self.single_player = (len(teams) == 1)
 
-        image_archives: list[Path] = []
+        image_archives: list = []
         for team in teams:
             build_commands = []
             build_commands.append(("solver-" + str(team.name), team.solver_path))

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -211,6 +211,7 @@ class Match(Subject):
 
         for path in image_archives:
             subprocess.Popen(["docker", "load", "-q", "-i", str(path)])
+            path.unlink()
         return len(self.team_names) > 0
 
     @build_successful
@@ -308,6 +309,9 @@ class Match(Subject):
                 self.solving_team = pair[1]
                 self.battle_wrapper.wrapper(self, options)
 
+        for team in self.team_names:
+            for role in ("generator", "solver"):
+                    subprocess.Popen(["docker", "image", "rm", "-f", f"{role}-{team}"])
         return self.match_data
 
     @docker_running

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -26,16 +26,16 @@ class Match(Subject):
     generating_team = None
     solving_team = None
     battle_wrapper = None
-    creation_flags = 0
+    creationflags = 0
 
     def __init__(self, problem: Problem, config_path: str, teams: list,
                  runtime_overhead=0, approximation_ratio=1.0,
                  cache_docker_containers=True, unsafe_build: bool = False) -> None:
 
         if os.name != 'posix':
-            self.creation_flags = subprocess.CREATE_NEW_PROCESS_GROUP
+            self.creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
         else:
-            self.creation_flags = 0
+            self.creationflags = 0
 
         config = configparser.ConfigParser()
         logger.debug('Using additional configuration options from file "%s".', config_path)
@@ -101,7 +101,7 @@ class Match(Subject):
         """Ensure that internal methods are only callable if docker is running."""
         def wrapper(self, *args, **kwargs):
             docker_running = subprocess.Popen(['docker', 'info'], stdout=subprocess.PIPE,
-                                              stderr=subprocess.PIPE, creationflags=self.creation_flags)
+                                              stderr=subprocess.PIPE, creationflags=self.creationflags)
             _ = docker_running.communicate()
             if docker_running.returncode:
                 logger.error('Could not connect to the docker daemon. Is docker running?')

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -135,7 +135,7 @@ def run_subprocess(run_command: list, input: bytes, timeout: float, suppress_out
     return raw_output, elapsed_time
 
 
-def build_image(base_cmd: list[str], name: str, path: Path | str, timeout: float | None) -> bool:
+def build_image(base_cmd: list, name: str, path: Path | str, timeout: float | None) -> bool:
     """Builds a docker image of the given name using the base_command.
 
     Parameters

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -135,8 +135,25 @@ def run_subprocess(run_command: list, input: bytes, timeout: float, suppress_out
     return raw_output, elapsed_time
 
 
-def build_image(base_cmd: list[str], name: str, path: Path | str, timeout: float | None, unsafe: bool = False) -> bool:
-    """Builds a docker image of the given name using the base_command."""
+def build_image(base_cmd: list[str], name: str, path: Path | str, timeout: float | None) -> bool:
+    """Builds a docker image of the given name using the base_command.
+
+    Parameters
+    ----------
+    base_cmd : list
+        A list containing a shared prefix of a command.
+    name : str
+        The intended name (tag) of the image.
+    path: Path
+        Path to the image.
+    timeout: float
+        Timeout after which the build process is terminated preemptively.
+
+    Returns
+    -------
+    bool
+        Determines whether an image with the given tag is now built and thus accessible.
+    """
     path = Path(path)
     build_successful = True
     with subprocess.Popen(

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -135,7 +135,7 @@ def run_subprocess(run_command: list, input: bytes, timeout: float, suppress_out
     return raw_output, elapsed_time
 
 
-def build_image(base_cmd: list, name: str, path: Path | str, timeout: float | None) -> bool:
+def build_image(base_cmd: list, name: str, path: Path, timeout: float) -> bool:
     """Builds a docker image of the given name using the base_command.
 
     Parameters

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -1,6 +1,7 @@
 """Collection of utility functions."""
 import os
 import logging
+from pathlib import Path
 import timeit
 import subprocess
 import importlib.util
@@ -13,7 +14,12 @@ import algobattle.sighandler as sigh
 from algobattle.problem import Problem
 
 
-logger = logging.getLogger('algobattle.util')
+logger = logging.getLogger("algobattle.util")
+
+
+creationflags = 0
+if os.name != "posix":
+    creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
 
 
 def import_problem_from_path(problem_path: str) -> Problem:
@@ -50,21 +56,24 @@ def measure_runtime_overhead() -> float:
         I/O overhead in seconds, rounded to two decimal places.
     """
     problem = DelaytestProblem.Problem()
-    config_path = os.path.join(os.path.dirname(os.path.abspath(algobattle.__file__)), 'config', 'config_delaytest.ini')
+    config_path = os.path.join(os.path.dirname(os.path.abspath(algobattle.__file__)), "config", "config_delaytest.ini")
     delaytest_path = DelaytestProblem.__file__[:-12]  # remove /__init__.py
-    delaytest_team = algobattle.team.Team(0, delaytest_path + '/generator', delaytest_path + '/solver')
+    delaytest_team = algobattle.team.Team(0, delaytest_path + "/generator", delaytest_path + "/solver")
 
     match = algobattle.match.Match(problem, config_path, [delaytest_team])
 
     if not match.build_successful:
-        logger.warning('Building a match for the time tolerance calculation failed!')
+        logger.warning("Building a match for the time tolerance calculation failed!")
         return 0
 
     overheads = []
     for i in range(5):
         sigh.latest_running_docker_image = "generator0"
-        _, timeout = run_subprocess(match.generator_base_run_command(match.space_generator) + ["generator0"],
-                                    input=str(50 * i).encode(), timeout=match.timeout_generator)
+        _, timeout = run_subprocess(
+            match.generator_base_run_command(match.space_generator) + ["generator0"],
+            input=str(50 * i).encode(),
+            timeout=match.timeout_generator,
+        )
         if not timeout:
             timeout = match.timeout_generator
         overheads.append(float(timeout))
@@ -124,6 +133,29 @@ def run_subprocess(run_command: list, input: bytes, timeout: float, suppress_out
     logger.debug('Approximate elapsed runtime: {}/{} seconds.'.format(elapsed_time, timeout))
 
     return raw_output, elapsed_time
+
+
+def build_image(base_cmd: list[str], name: str, path: Path | str, timeout: float | None, unsafe: bool = False) -> bool:
+    """Builds a docker image of the given name using the base_command."""
+    path = Path(path)
+    build_successful = True
+    with subprocess.Popen(
+        base_cmd + [name, str(path)], stdout=subprocess.PIPE, stderr=subprocess.PIPE, creationflags=creationflags
+    ) as process:
+        try:
+            output, _ = process.communicate(timeout=timeout)
+            logger.debug(output.decode())
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+            logger.error(f"Build process for {name} ran into a timeout!")
+            build_successful = False
+        if process.returncode != 0:
+            process.kill()
+            process.wait()
+            logger.error(f"Build process for {name} failed!")
+            build_successful = False
+    return build_successful
 
 
 def update_nested_dict(current_dict, updates):

--- a/scripts/battle
+++ b/scripts/battle
@@ -95,6 +95,7 @@ if __name__ == "__main__":
     parser.add_option('--silent', dest='silent', action='store_true', help='Disable forking the logging output to stderr.')
     parser.add_option('--no_overhead_calculation', dest='no_overhead_calculation', action='store_true', help='If set, the program does not benchmark the I/O of the host system to calculate the runtime overhead when started.')
     parser.add_option('--ui', dest='display_ui', action='store_true', help='If set, the program sets the --silent option and displays a small ui on STDOUT that shows the progress of the battles.')
+    parser.add_option('--unsafe_build', dest='unsafe_build', action='store_true', help='If set, the build processes of the docker containers will not be isolated from each other.')
 
     (options, args) = parser.parse_args()
 
@@ -140,7 +141,7 @@ if __name__ == "__main__":
         runtime_overhead = measure_runtime_overhead()
         logger.info('Maximal measured runtime overhead is at {} seconds. Adding this amount to the configured runtime.'.format(runtime_overhead))
 
-    match = Match(problem, options.config, teams, runtime_overhead=runtime_overhead, approximation_ratio=options.approximation_ratio)
+    match = Match(problem, options.config, teams, runtime_overhead=runtime_overhead, approximation_ratio=options.approximation_ratio, unsafe_build=options.unsafe_build)
 
     if not match.build_successful:
         logger.critical('Building the match object failed, exiting!')


### PR DESCRIPTION
this addresses #64 by isolating the build environments of each image from each other. To do this I archive the newly created image to disk. This comes at a significant performance hit so I also introduced the `--unsafe_build` CLI flag to have quicker local debugging runs.