### PR TITLE
Gracefully handle unicode encoding errors

### DIFF
--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -184,7 +184,7 @@ class Match(Subject):
                                       stderr=subprocess.PIPE, creationflags=creationflags) as process:
                     try:
                         output, _ = process.communicate(timeout=self.timeout_build)
-                        logger.debug(output.decode())
+                        logger.debug(output.decode(errors="ignore"))
                     except subprocess.TimeoutExpired:
                         process.kill()
                         process.wait()

--- a/algobattle/parser.py
+++ b/algobattle/parser.py
@@ -109,7 +109,7 @@ class Parser(ABC):
         bytes
             Returns the input as a byte object.
         """
-        return "\n".join(str(" ".join(str(element) for element in line)) for line in input).encode()
+        return "\n".join(str(" ".join(str(element) for element in line)) for line in input).encode(errors="ignore")
 
     @abstractmethod
     def decode(self, raw_input: bytes) -> any:
@@ -129,4 +129,4 @@ class Parser(ABC):
         any
             Returns the decoded input.
         """
-        return [tuple(line.split()) for line in raw_input.decode().splitlines() if line.split()]
+        return [tuple(line.split()) for line in raw_input.decode(errors="ignore").splitlines() if line.split()]


### PR DESCRIPTION
This makes it so that incorrect unicode sequences generated by the docker containers are omitted in the decoded string rather than raising an error.
@Benezivas you need to also check if any of the problems you're using right now use a parser that overwrites the `.decode()` method and apply the same change there.