### PR TITLE
use entrypoints to include custom wrappers

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -12,6 +12,10 @@ from typing import Literal
 import tomli
 from algobattle.battle_wrapper import BattleWrapper
 
+# for now we need to manually import the default wrappers to make sure they're initialized
+from algobattle.battle_wrappers.iterated import Iterated    # type: ignore
+from algobattle.battle_wrappers.averaged import Averaged    # type: ignore
+
 from algobattle.match import MatchConfig, run_match
 from algobattle.team import TeamHandler, TeamInfo
 from algobattle.ui import Ui

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -13,8 +13,8 @@ import tomli
 from algobattle.battle_wrapper import BattleWrapper
 
 # for now we need to manually import the default wrappers to make sure they're initialized
-from algobattle.battle_wrappers.iterated import Iterated    # type: ignore
-from algobattle.battle_wrappers.averaged import Averaged    # type: ignore
+from algobattle.battle_wrappers.iterated import Iterated    # type: ignore # noqa: F401
+from algobattle.battle_wrappers.averaged import Averaged    # type: ignore # noqa: F401
 
 from algobattle.match import MatchConfig, run_match
 from algobattle.team import TeamHandler, TeamInfo

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -16,8 +16,6 @@ from algobattle.match import MatchConfig, run_match
 from algobattle.team import TeamHandler, TeamInfo
 from algobattle.ui import Ui
 from algobattle.util import check_path, getattr_set, import_problem_from_path
-from algobattle.battle_wrappers.averaged import Averaged
-from algobattle.battle_wrappers.iterated import Iterated
 
 
 def setup_logging(logging_path: Path, verbose_logging: bool, silent: bool):
@@ -88,7 +86,7 @@ def parse_cli_args(args: list[str]) -> tuple[ProgramConfig, MatchConfig, BattleW
     parser.add_argument("--verbose", "-v", dest="verbose", action="store_const", const=True, help="More detailed log output.")
     parser.add_argument("--safe_build", action="store_const", const=True, help="Isolate docker image builds from each other. Significantly slows down battle setup but closes prevents images from interfering with each other.")
 
-    parser.add_argument("--battle_type", choices=["iterated", "averaged"], help="Type of battle wrapper to be used.")
+    parser.add_argument("--battle_type", choices=[name.lower() for name in BattleWrapper.all()], help="Type of battle wrapper to be used.")
     parser.add_argument("--rounds", type=int, help="Number of rounds that are to be fought in the battle (points are split between all rounds).")
     parser.add_argument("--points", type=int, help="number of points distributed between teams.")
 
@@ -100,10 +98,10 @@ def parse_cli_args(args: list[str]) -> tuple[ProgramConfig, MatchConfig, BattleW
     parser.add_argument("--cpus", type=int, help="Number of cpu cores used for each docker container execution.")
 
     # battle wrappers have their configs automatically added to the CLI args
-    for wrapper in (Iterated, Averaged):
-        group = parser.add_argument_group(wrapper.name())
+    for wrapper_name, wrapper in BattleWrapper.all().items():
+        group = parser.add_argument_group(wrapper_name)
         for name, kwargs in wrapper.Config.as_argparse_args():
-            group.add_argument(f"--{wrapper.name().lower()}_{name}", **kwargs)
+            group.add_argument(f"--{wrapper_name.lower()}_{name}", **kwargs)
 
     parsed = parser.parse_args(args)
 

--- a/algobattle/battle_wrapper.py
+++ b/algobattle/battle_wrapper.py
@@ -7,6 +7,7 @@ their run, such that it contains the current state of the match.
 """
 from __future__ import annotations
 from dataclasses import dataclass
+from importlib.metadata import entry_points
 import logging
 from abc import abstractmethod, ABC
 from importlib import import_module
@@ -28,6 +29,22 @@ class BattleWrapper(ABC):
         """Object containing the config variables the wrapper will use."""
 
         pass
+
+    __wrappers: dict[str, Type[BattleWrapper]] = {}
+
+    @staticmethod
+    def all() -> dict[str, Type[BattleWrapper]]:
+        """Returns a list of all registered wrappers."""
+        for entrypoint in entry_points(group="algobattle.wrappers"):
+            if entrypoint.name not in BattleWrapper.__wrappers:
+                BattleWrapper.__wrappers = entrypoint.load()
+        return BattleWrapper.__wrappers
+
+    def __init_subclass__(cls) -> None:
+        if cls.name() not in BattleWrapper.__wrappers:
+            BattleWrapper.__wrappers[cls.name()] = cls
+        return super().__init_subclass__()
+
 
     @staticmethod
     def get_wrapper(wrapper_name: str) -> Type[BattleWrapper]:

--- a/algobattle/battle_wrapper.py
+++ b/algobattle/battle_wrapper.py
@@ -46,7 +46,6 @@ class BattleWrapper(ABC):
             BattleWrapper._wrappers[cls.name()] = cls
         return super().__init_subclass__()
 
-
     @staticmethod
     def get_wrapper(wrapper_name: str) -> Type[BattleWrapper]:
         """Try to import a Battle Wrapper from a given name.

--- a/algobattle/battle_wrapper.py
+++ b/algobattle/battle_wrapper.py
@@ -30,19 +30,20 @@ class BattleWrapper(ABC):
 
         pass
 
-    __wrappers: dict[str, Type[BattleWrapper]] = {}
+    _wrappers: dict[str, Type[BattleWrapper]] = {}
 
     @staticmethod
     def all() -> dict[str, Type[BattleWrapper]]:
         """Returns a list of all registered wrappers."""
         for entrypoint in entry_points(group="algobattle.wrappers"):
-            if entrypoint.name not in BattleWrapper.__wrappers:
-                BattleWrapper.__wrappers = entrypoint.load()
-        return BattleWrapper.__wrappers
+            if entrypoint.name not in BattleWrapper._wrappers:
+                wrapper: Type[BattleWrapper] = entrypoint.load()
+                BattleWrapper._wrappers[wrapper.name()] = wrapper
+        return BattleWrapper._wrappers
 
     def __init_subclass__(cls) -> None:
-        if cls.name() not in BattleWrapper.__wrappers:
-            BattleWrapper.__wrappers[cls.name()] = cls
+        if cls.name() not in BattleWrapper._wrappers:
+            BattleWrapper._wrappers[cls.name()] = cls
         return super().__init_subclass__()
 
 


### PR DESCRIPTION
this PR makes it easier to include custom wrappers, instead of having to put them into a file in the battle_wrappers folder you can now just install them in your own package with a pyproject.toml that includes something like:
```toml
[project.entry-points."algobattle.wrappers"]
NewWrapper= "my.own.module:NewWrapper"
```
and we will automatically include it in the battle structure.