### PR TITLE
Use pydantic to parse configs

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -17,7 +17,7 @@ from typing import (
     get_type_hints,
 )
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, BaseConfig
 
 from algobattle.docker_util import DockerError, Generator, Solver, GeneratorResult, SolverResult
 from algobattle.ui import Subject
@@ -65,6 +65,9 @@ class Battle(Subject, ABC):
 
                 arguments.append((field.name, kwargs))
             return arguments
+
+        class Config(BaseConfig):
+            validate_assignment = True
 
     @staticmethod
     def all() -> dict[str, type["Battle"]]:

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -67,6 +67,8 @@ class Battle(Subject, ABC):
             return arguments
 
         class Config(BaseConfig):
+            """Pydandtic config."""
+
             validate_assignment = True
 
     @staticmethod

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -49,10 +49,6 @@ class Battle(Subject, ABC):
     class Config(BaseModel):
         """Object containing the config variables the battle types use."""
 
-        # providing a dummy default impl that will be overriden, to get better static analysis
-        def __init__(self, **kwargs) -> None:
-            super().__init__()
-
         @classmethod
         def as_argparse_args(cls) -> list[tuple[str, dict[str, Any]]]:
             """Constructs a list of argument names and `**kwargs` that can be passed to `ArgumentParser.add_argument()`."""

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -13,12 +13,12 @@ import tomllib
 from pydantic import BaseModel, Field
 
 from algobattle.battle import Battle
-from algobattle.docker_util import DockerConfig, RunParameters
+from algobattle.docker_util import DockerConfig
 from algobattle.match import MatchConfig, Match
 from algobattle.problem import Problem
 from algobattle.team import TeamHandler, TeamInfo
 from algobattle.ui import Ui
-from algobattle.util import check_path, getattr_set
+from algobattle.util import check_path
 
 
 def setup_logging(logging_path: Path, verbose_logging: bool, silent: bool):

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Literal, Mapping, Self
 import tomllib
 
-from pydantic import BaseModel, ValidationError, validator
+from pydantic import BaseModel, validator
 
 from algobattle.battle import Battle
 from algobattle.docker_util import DockerConfig
@@ -90,10 +90,12 @@ class Config(BaseModel):
 
     @property
     def battle_config(self) -> Battle.Config:
+        """The config object for the used battle type."""
         return self.battle[self.match.battle_type.name().lower()]
 
     @validator("battle")
     def val_battle_configs(cls, vals):
+        """Parses the dict of battle configs into their corresponding config objects."""
         battle_types = Battle.all()
         if not isinstance(vals, Mapping):
             raise TypeError

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -9,10 +9,12 @@ import logging
 import datetime as dt
 from pathlib import Path
 from typing import Literal
+
 import tomli
+from pydantic import BaseModel
+
 from algobattle.battle import Battle
 from algobattle.docker_util import DockerConfig, RunParameters
-
 from algobattle.match import MatchConfig, Match
 from algobattle.problem import Problem
 from algobattle.team import TeamHandler, TeamInfo
@@ -65,6 +67,17 @@ def setup_logging(logging_path: Path, verbose_logging: bool, silent: bool):
 
     logger.info(f"You can find the log files for this run in {logging_path}")
     return logger
+
+
+class Config(BaseModel):
+    """Pydantic model to parse the config file."""
+
+    problem: Path
+    teams: list[TeamInfo]
+    display: Literal["silent", "logs", "ui"] = "logs"
+    logs: Path = Path.home() / ".algobattle_logs"
+    match: MatchConfig
+    docker: DockerConfig
 
 
 @dataclass

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -74,7 +74,7 @@ class Config(BaseModel):
     problem: Path
     teams: list[TeamInfo] = []
     display: Literal["silent", "logs", "ui"] = "logs"
-    logs: Path = Field(Path.home() / ".algobattle_logs", cli_alias="logging_path")
+    logs: Path = Field(default=Path.home() / ".algobattle_logs", cli_alias="logging_path")
     match: MatchConfig
     docker: DockerConfig
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -72,6 +72,7 @@ def setup_logging(logging_path: Path, verbose_logging: bool, silent: bool):
 
 class ExecutionConfig(BaseModel):
     """Config data regarding program execution."""
+
     display: Literal["silent", "logs", "ui"] = "logs"
     logging_path: Path = Path.home() / ".algobattle_logs"
     verbose: bool = False

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -224,9 +224,9 @@ def main():
             logger.info("#" * 78)
             logger.info(result.display())
             if config.match.points > 0:
-                points = result.calculate_points(config.match.points)
+                points = result.calculate_points()
                 for team, pts in points.items():
-                    logger.info(f"Group {team} gained {pts:.1f} points.")
+                    logger.info(f"Team {team} gained {pts:.1f} points.")
 
     except KeyboardInterrupt:
         logger.critical("Received keyboard interrupt, terminating execution.")

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -206,12 +206,15 @@ def parse_cli_args(args: list[str]) -> tuple[Path, Config]:
 
     if parsed.battle_type is not None:
         parsed.battle_type = Battle.all()[parsed.battle_type]
-    cfg_path = parsed.config if parsed.config is not None else parsed.problem / "config.toml"
+    cfg_path: Path = parsed.config or parsed.problem / "config.toml"
 
-    try:
-        config = Config.from_file(cfg_path)
-    except Exception as e:
-        raise ValueError(f"Invalid config file, terminating execution.\n{e}")
+    if cfg_path.is_file():
+        try:
+            config = Config.from_file(cfg_path)
+        except Exception as e:
+            raise ValueError(f"Invalid config file, terminating execution.\n{e}")
+    else:
+        config = Config()
     config.include_cli(parsed)
 
     if not config.teams:

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Literal
 import tomllib
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ValidationError
 
 from algobattle.battle import Battle
 from algobattle.docker_util import DockerConfig
@@ -47,20 +47,22 @@ def setup_logging(logging_path: Path, verbose_logging: bool, silent: bool):
 
     t = dt.datetime.now()
     current_timestamp = f"{t.year:04d}-{t.month:02d}-{t.day:02d}_{t.hour:02d}-{t.minute:02d}-{t.second:02d}"
-    logging_path = Path(logging_path, current_timestamp + '.log')
+    logging_path = Path(logging_path, current_timestamp + ".log")
 
-    logging.basicConfig(handlers=[logging.FileHandler(logging_path, 'w', 'utf-8')],
-                        level=common_logging_level,
-                        format='%(asctime)s %(levelname)s: %(message)s',
-                        datefmt='%H:%M:%S')
-    logger = logging.getLogger('algobattle')
+    logging.basicConfig(
+        handlers=[logging.FileHandler(logging_path, "w", "utf-8")],
+        level=common_logging_level,
+        format="%(asctime)s %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    logger = logging.getLogger("algobattle")
 
     if not silent:
         # Pipe logging out to console
         _consolehandler = logging.StreamHandler(stream=sys.stderr)
         _consolehandler.setLevel(common_logging_level)
 
-        _consolehandler.setFormatter(logging.Formatter('%(message)s'))
+        _consolehandler.setFormatter(logging.Formatter("%(message)s"))
 
         logger.addHandler(_consolehandler)
 
@@ -80,16 +82,8 @@ class Config(BaseModel):
     _cli_mapping: ClassVar[dict[str, Any]] = {
         "teams": None,
         "docker": {
-            "generator": {
-                "timeout": "generator_timeout",
-                "space": "generator_space",
-                "cpus": "generator_cpus",
-            },
-            "solver": {
-                "timeout": "solver_timeout",
-                "space": "solver_space",
-                "cpus": "solver_cpus",
-            },
+            "generator": {"timeout": "generator_timeout", "space": "generator_space", "cpus": "generator_cpus"},
+            "solver": {"timeout": "solver_timeout", "space": "solver_space", "cpus": "solver_cpus"},
         },
     }
 
@@ -115,15 +109,36 @@ def parse_cli_args(args: list[str]) -> tuple[Path, Config, Battle.Config]:
     """Parse a given CLI arg list into config objects."""
     parser = ArgumentParser()
     parser.add_argument("problem", type=check_path, help="Path to a folder with the problem file.")
-    parser.add_argument("--config", type=partial(check_path, type="file"), help="Path to a config file, defaults to '{problem} / config.toml'.")
-    parser.add_argument("--logging_path", type=partial(check_path, type="dir"), help="Folder that logs are written into, defaults to '~/.algobattle_logs'.")
-    parser.add_argument("--display", choices=["silent", "logs", "ui"], help="Choose output mode, silent disables all output, logs displays the battle logs on STDERR, ui displays a small GUI showing the progress of the battle. Default: logs.")
+    parser.add_argument(
+        "--config", type=partial(check_path, type="file"), help="Path to a config file, defaults to '{problem} / config.toml'."
+    )
+    parser.add_argument(
+        "--logging_path",
+        type=partial(check_path, type="dir"),
+        help="Folder that logs are written into, defaults to '~/.algobattle_logs'.",
+    )
+    parser.add_argument(
+        "--display",
+        choices=["silent", "logs", "ui"],
+        help="Choose output mode, silent disables all output, logs displays the battle logs on STDERR,"
+        " ui displays a small GUI showing the progress of the battle. Default: logs.",
+    )
 
     parser.add_argument("--verbose", "-v", dest="verbose", action="store_const", const=True, help="More detailed log output.")
-    parser.add_argument("--safe_build", action="store_const", const=True, help="Isolate docker image builds from each other. Significantly slows down battle setup but closes prevents images from interfering with each other.")
+    parser.add_argument(
+        "--safe_build",
+        action="store_const",
+        const=True,
+        help="Isolate docker image builds from each other. Significantly slows down battle setup"
+        " but prevents images from interfering with each other.",
+    )
 
     parser.add_argument("--battle_type", choices=[name.lower() for name in Battle.all()], help="Type of battle to be used.")
-    parser.add_argument("--rounds", type=int, help="Number of rounds that are to be fought in the battle (points are split between all rounds).")
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        help="Number of rounds that are to be fought in the battle (points are split between all rounds).",
+    )
     parser.add_argument("--points", type=int, help="number of points distributed between teams.")
 
     parser.add_argument("--build_timeout", type=float, help="Timeout for the build step of each docker image.")
@@ -162,11 +177,7 @@ def parse_cli_args(args: list[str]) -> tuple[Path, Config, Battle.Config]:
     config.include_cli(parsed)
 
     if not config.teams:
-        config.teams.append(TeamInfo(
-            name="team_0",
-            generator=problem / "generator",
-            solver=problem / "solver",
-        ))
+        config.teams.append(TeamInfo(name="team_0", generator=problem / "generator", solver=problem / "solver"))
 
     battle_type = config.match.battle_type
     battle_name = battle_type.name().lower()
@@ -203,7 +214,7 @@ def main():
 
             result = Match.run(config.match, battle_config, problem, teams, ui)
 
-            logger.info('#' * 78)
+            logger.info("#" * 78)
             logger.info(result.display())
             if config.match.points > 0:
                 points = result.calculate_points(config.match.points)

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -88,6 +88,10 @@ class Config(BaseModel):
     docker: DockerConfig = DockerConfig()
     battle: dict[str, Battle.Config] = {n: b.Config() for n, b in Battle.all().items()}
 
+    @property
+    def battle_config(self) -> Battle.Config:
+        return self.battle[self.match.battle_type.name().lower()]
+
     @validator("battle")
     def val_battle_configs(cls, vals):
         battle_types = Battle.all()
@@ -232,7 +236,7 @@ def main():
             else:
                 ui = None
 
-            result = Match.run(config.match, config.battle[config.match.battle_type.name().lower()], problem, teams, ui)
+            result = Match.run(config.match, config.battle_config, problem, teams, ui)
 
             logger.info("#" * 78)
             logger.info(result.display())

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -71,7 +71,7 @@ def setup_logging(logging_path: Path, verbose_logging: bool, silent: bool):
 class Config(BaseModel):
     """Pydantic model to parse the config file."""
 
-    problem: Path
+    problem: Path = Path()
     teams: list[TeamInfo] = []
     display: Literal["silent", "logs", "ui"] = "logs"
     logging_path: Path = Field(default=Path.home() / ".algobattle_logs", cli_alias="logging_path")
@@ -83,13 +83,13 @@ class Config(BaseModel):
         "docker": {
             "generator": {
                 "timeout": "generator_timeout",
-                "spcace": "generator_space",
+                "space": "generator_space",
                 "cpus": "generator_cpus",
             },
             "solver": {
-                "timeout": "space_timeout",
-                "spcace": "space_space",
-                "cpus": "space_cpus",
+                "timeout": "solver_timeout",
+                "space": "solver_space",
+                "cpus": "solver_cpus",
             },
         },
     }

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -93,18 +93,16 @@ class Config(BaseModel):
         """The config object for the used battle type."""
         return self.battle[self.match.battle_type.name().lower()]
 
-    @validator("battle")
+    @validator("battle", pre=True)
     def val_battle_configs(cls, vals):
         """Parses the dict of battle configs into their corresponding config objects."""
         battle_types = Battle.all()
         if not isinstance(vals, Mapping):
             raise TypeError
         out = {}
-        for name, data in vals.items():
-            if name in battle_types:
-                out[name] = battle_types[name].Config.parse_obj(data)
-            else:
-                raise ValueError
+        for name, battle_cls in battle_types.items():
+            data = vals.get(name, {})
+            out[name] = battle_cls.Config.parse_obj(data)
         return out
 
     _cli_mapping: ClassVar[dict[str, Any]] = {

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -75,8 +75,8 @@ class Config(BaseModel):
     teams: list[TeamInfo] = []
     display: Literal["silent", "logs", "ui"] = "logs"
     logging_path: Path = Field(default=Path.home() / ".algobattle_logs", cli_alias="logging_path")
-    match: MatchConfig
-    docker: DockerConfig
+    match: MatchConfig = MatchConfig()
+    docker: DockerConfig = DockerConfig()
 
     _cli_mapping: ClassVar[dict[str, Any]] = {
         "teams": None,

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -231,7 +231,7 @@ def main():
 
     try:
         problem = Problem.import_from_path(problem)
-        with TeamHandler.build(config.teams, problem, config.docker) as teams, ExitStack() as stack:
+        with TeamHandler.build(config.teams, problem, config.docker, config.execution.safe_build) as teams, ExitStack() as stack:
             if config.execution.display == "ui":
                 ui = Ui()
                 stack.enter_context(ui)

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -168,8 +168,8 @@ def parse_cli_args(args: list[str]) -> tuple[Config, Battle.Config]:
     battle_type = config.match.battle_type
     battle_name = battle_type.name().lower()
     battle_config_dict = config_dict.get(battle_name, {})
-    battle_config = battle_type.Config(**battle_config_dict)
-    for name in vars(battle_config):
+    battle_config = battle_type.Config.parse_obj(battle_config_dict)
+    for name in battle_config.__fields__:
         cli_name = f"{battle_name}_{name}"
         if getattr(parsed, cli_name) is not None:
             setattr(battle_config, name, getattr(parsed, cli_name))

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -18,7 +18,7 @@ from requests import Timeout
 from algobattle.util import Encodable, Role, TempDir, encode, decode, inherit_docs
 from algobattle.problem import Problem
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger("algobattle.docker")
 
@@ -26,22 +26,20 @@ logger = logging.getLogger("algobattle.docker")
 _client_var: DockerClient | None = None
 
 
-@dataclass(frozen=True)
-class RunParameters:
+class RunParameters(BaseModel):
     """The parameters determining how a container is run."""
 
-    timeout: float | None = Field(30, cli_alias="timeout")
-    space: int | None = Field(None, cli_alias="space")
-    cpus: int = Field(1, cli_alias="cpus")
+    timeout: float | None = Field(default=30, cli_alias="timeout")
+    space: int | None = Field(default=None, cli_alias="space")
+    cpus: int = Field(default=1, cli_alias="cpus")
 
 
-@dataclass(frozen=True)
-class DockerConfig:
+class DockerConfig(BaseModel):
     """Grouped config options that are relevant to the interaction with docker."""
 
-    build_timeout: float | None = Field(None, cli_alias="build_timeout")
-    generator: RunParameters = Field(RunParameters(), cli_alias="generator")
-    solver: RunParameters = Field(RunParameters(), cli_alias="solver")
+    build_timeout: float | None = Field(default=None, cli_alias="build_timeout")
+    generator: RunParameters = Field(default=RunParameters(), cli_alias="generator")
+    solver: RunParameters = Field(default=RunParameters(), cli_alias="solver")
 
 
 def client() -> DockerClient:

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -18,7 +18,7 @@ from requests import Timeout
 from algobattle.util import Encodable, Role, TempDir, encode, decode, inherit_docs
 from algobattle.problem import Problem
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 logger = logging.getLogger("algobattle.docker")
 
@@ -29,17 +29,17 @@ _client_var: DockerClient | None = None
 class RunParameters(BaseModel):
     """The parameters determining how a container is run."""
 
-    timeout: float | None = Field(default=30, cli_alias="timeout")
-    space: int | None = Field(default=None, cli_alias="space")
-    cpus: int = Field(default=1, cli_alias="cpus")
+    timeout: float | None = 30
+    space: int | None = None
+    cpus: int = 1
 
 
 class DockerConfig(BaseModel):
     """Grouped config options that are relevant to the interaction with docker."""
 
-    build_timeout: float | None = Field(default=None, cli_alias="build_timeout")
-    generator: RunParameters = Field(default=RunParameters(), cli_alias="generator")
-    solver: RunParameters = Field(default=RunParameters(), cli_alias="solver")
+    build_timeout: float | None = None
+    generator: RunParameters = RunParameters()
+    solver: RunParameters = RunParameters()
 
 
 def client() -> DockerClient:

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -18,6 +18,7 @@ from requests import Timeout
 from algobattle.util import Encodable, Role, TempDir, encode, decode, inherit_docs
 from algobattle.problem import Problem
 
+from pydantic import Field
 
 logger = logging.getLogger("algobattle.docker")
 
@@ -29,18 +30,18 @@ _client_var: DockerClient | None = None
 class RunParameters:
     """The parameters determining how a container is run."""
 
-    timeout: float | None = 30
-    space: int | None = None
-    cpus: int = 1
+    timeout: float | None = Field(30, cli_alias="timeout")
+    space: int | None = Field(None, cli_alias="space")
+    cpus: int = Field(1, cli_alias="cpus")
 
 
 @dataclass(frozen=True)
 class DockerConfig:
     """Grouped config options that are relevant to the interaction with docker."""
 
-    build_timeout: float | None = None
-    generator: RunParameters = RunParameters()
-    solver: RunParameters = RunParameters()
+    build_timeout: float | None = Field(None, cli_alias="build_timeout")
+    generator: RunParameters = Field(RunParameters(), cli_alias="generator")
+    solver: RunParameters = Field(RunParameters(), cli_alias="solver")
 
 
 def client() -> DockerClient:

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -17,8 +17,6 @@ logger = logging.getLogger("algobattle.match")
 class MatchConfig(BaseModel):
     """Parameters determining the match execution."""
 
-    verbose: bool = False
-    safe_build: bool = False
     battle_type: type[Battle] = Iterated
     rounds: int = 5
     points: int = 100

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -23,17 +23,17 @@ class MatchConfig(BaseModel):
     rounds: int = 5
     points: int = 100
 
-    @validator("battle_type")
+    @validator("battle_type", pre=True)
     def parse_battle_type(cls, value):
         """Parses the battle type class object from its name."""
-        if issubclass(value, Battle):
-            return value
-        elif isinstance(value, str):
+        if isinstance(value, str):
             all = Battle.all()
             if value in all:
                 return all[value]
             else:
                 raise ValueError
+        elif issubclass(value, Battle):
+            return value
         else:
             raise TypeError
 

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -1,9 +1,10 @@
 """Central managing module for an algorithmic battle."""
 from __future__ import annotations
-from dataclasses import dataclass
 import logging
 from typing import Any, Self
+
 from prettytable import PrettyTable, DOUBLE_BORDER
+from pydantic import BaseModel
 
 from algobattle.battle import Battle, Iterated
 from algobattle.ui import Observer, Subject
@@ -13,8 +14,7 @@ from algobattle.problem import Problem
 logger = logging.getLogger("algobattle.match")
 
 
-@dataclass(kw_only=True)
-class MatchConfig:
+class MatchConfig(BaseModel):
     """Parameters determining the match execution."""
 
     verbose: bool = False

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -7,7 +7,7 @@ from prettytable import PrettyTable, DOUBLE_BORDER
 
 from algobattle.battle import Battle, Iterated
 from algobattle.ui import Observer, Subject
-from algobattle.team import Matchup, Team, TeamHandler
+from algobattle.team import Matchup, TeamHandler
 from algobattle.problem import Problem
 
 logger = logging.getLogger("algobattle.match")

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -78,12 +78,13 @@ class Match(Subject):
                 result.notify("match")
         return result
 
-    def calculate_points(self, achievable_points: int) -> dict[str, float]:
+    def calculate_points(self) -> dict[str, float]:
         """Calculate the number of points each team scored.
 
         Each pair of teams fights for the achievable points among one another.
         These achievable points are split over all rounds.
         """
+        achievable_points = self.config.points
         if len(self.teams.active) == 0:
             return {}
         if len(self.teams.active) == 1:

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Self
 
 from prettytable import PrettyTable, DOUBLE_BORDER
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from algobattle.battle import Battle, Iterated
 from algobattle.ui import Observer, Subject
@@ -22,6 +22,20 @@ class MatchConfig(BaseModel):
     battle_type: type[Battle] = Iterated
     rounds: int = 5
     points: int = 100
+
+    @validator("battle_type")
+    def parse_battle_type(cls, value):
+        """Parses the battle type class object from its name."""
+        if issubclass(value, Battle):
+            return value
+        elif isinstance(value, str):
+            all = Battle.all()
+            if value in all:
+                return all[value]
+            else:
+                raise ValueError
+        else:
+            raise TypeError
 
     @staticmethod
     def from_dict(info: dict[str, Any]) -> MatchConfig:

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, validator
 
 from algobattle.battle import Battle, Iterated
 from algobattle.ui import Observer, Subject
-from algobattle.team import Matchup, TeamHandler
+from algobattle.team import Matchup, TeamHandler, Team
 from algobattle.problem import Problem
 
 logger = logging.getLogger("algobattle.match")

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -1,7 +1,7 @@
 """Central managing module for an algorithmic battle."""
 from __future__ import annotations
 import logging
-from typing import Any, Self
+from typing import Self
 
 from prettytable import PrettyTable, DOUBLE_BORDER
 from pydantic import BaseModel, validator
@@ -36,19 +36,6 @@ class MatchConfig(BaseModel):
             return value
         else:
             raise TypeError
-
-    @staticmethod
-    def from_dict(info: dict[str, Any]) -> MatchConfig:
-        """Parses a :cls:`MatchConfig` from a dict."""
-        if "battle_type" in info:
-            try:
-                battle_type = Battle.all()[info["battle_type"]]
-            except KeyError:
-                raise ValueError(f"Attempted to use invalid battle type {info['battle_type']}.")
-            update = {"battle_type": battle_type}
-        else:
-            update = {}
-        return MatchConfig(**(info | update))
 
 
 class Match(Subject):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "windows-curses; os_name == 'nt'",
 
     "prettytable",
-    "tomli",
     "pydantic",
 ]
 

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -8,5 +8,5 @@ battle_type = "averaged"
 [docker.generator]
 space = 10
 
-[averaged]
+[battle.averaged]
 iterations = 1

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,6 +1,8 @@
+[execution]
+safe_build = true
+
 [match]
 points = 10
-safe_build = true
 battle_type = "averaged"
 
 [docker.generator]

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -190,21 +190,21 @@ class Parsing(TestCase):
         )]
 
     def test_no_cfg_default(self):
-        problem, cfg, battle_cfg = parse_cli_args([str(self.problem_path)])
+        problem, cfg = parse_cli_args([str(self.problem_path)])
         self.assertEqual(problem, self.problem_path)
         self.assertEqual(cfg, Config(teams=self.teams))
-        self.assertEqual(battle_cfg, Iterated.Config())
+        self.assertEqual(cfg.battle_config, Iterated.Config())
 
     def test_empty_cfg(self):
-        problem, cfg, battle_cfg = parse_cli_args(
+        problem, cfg = parse_cli_args(
             [str(self.problem_path), "--config", str(self.configs_path / "empty.toml")]
         )
         self.assertEqual(problem, self.problem_path)
         self.assertEqual(cfg, Config(teams=self.teams))
-        self.assertEqual(battle_cfg, Iterated.Config())
+        self.assertEqual(cfg.battle_config, Iterated.Config())
 
     def test_cfg(self):
-        problem, cfg, battle_cfg = parse_cli_args(
+        problem, cfg = parse_cli_args(
             [str(self.problem_path), "--config", str(self.configs_path / "test.toml")]
         )
         self.assertEqual(problem, self.problem_path)
@@ -217,10 +217,10 @@ class Parsing(TestCase):
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
         ))
-        self.assertEqual(battle_cfg, Averaged.Config(iterations=1))
+        self.assertEqual(cfg.battle_config, Averaged.Config(iterations=1))
 
     def test_cli(self):
-        problem, cfg, battle_cfg = parse_cli_args(
+        problem, cfg = parse_cli_args(
             [
                 str(self.problem_path),
                 "--points=10",
@@ -240,10 +240,10 @@ class Parsing(TestCase):
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
         ))
-        self.assertEqual(battle_cfg, Averaged.Config(iterations=1))
+        self.assertEqual(cfg.battle_config, Averaged.Config(iterations=1))
 
     def test_cli_overwrite_cfg(self):
-        problem, cfg, battle_cfg = parse_cli_args(
+        problem, cfg = parse_cli_args(
             [
                 str(self.problem_path),
                 "--points=20",
@@ -263,7 +263,7 @@ class Parsing(TestCase):
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
         ))
-        self.assertEqual(battle_cfg, Iterated.Config())
+        self.assertEqual(cfg.battle_config, Iterated.Config())
 
     def test_cli_no_problem_path(self):
         with self.assertRaises(SystemExit):
@@ -274,7 +274,7 @@ class Parsing(TestCase):
             parse_cli_args([str(self.problem_path), "--battle_type=NotABattleType"])
 
     def test_cfg_team(self):
-        _, cfg, _ = parse_cli_args([str(self.problem_path), f"--config={self.configs_path / 'teams.toml'}"])
+        _, cfg = parse_cli_args([str(self.problem_path), f"--config={self.configs_path / 'teams.toml'}"])
         self.assertEqual(cfg, Config(
             teams=[TeamInfo("team 1", Path(), Path()), TeamInfo("team 2", Path(), Path())]
         ))

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -4,8 +4,6 @@ from unittest import TestCase, main
 import logging
 from pathlib import Path
 
-from pydantic import ValidationError
-
 from algobattle.cli import Config, parse_cli_args, setup_logging
 from algobattle.battle import Iterated, Averaged
 from algobattle.match import MatchConfig, Match

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -216,8 +216,10 @@ class Parsing(TestCase):
             teams=self.teams,
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
+            battle={
+                "averaged": Averaged.Config(iterations=1),
+            }
         ))
-        self.assertEqual(cfg.battle_config, Averaged.Config(iterations=1))
 
     def test_cli(self):
         problem, cfg = parse_cli_args(
@@ -239,8 +241,10 @@ class Parsing(TestCase):
             teams=self.teams,
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
+            battle={
+                "averaged": Averaged.Config(iterations=1),
+            },
         ))
-        self.assertEqual(cfg.battle_config, Averaged.Config(iterations=1))
 
     def test_cli_overwrite_cfg(self):
         problem, cfg = parse_cli_args(
@@ -262,8 +266,10 @@ class Parsing(TestCase):
             teams=self.teams,
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
+            battle={
+                "averaged": Averaged.Config(iterations=1),
+            },
         ))
-        self.assertEqual(cfg.battle_config, Iterated.Config())
 
     def test_cli_no_problem_path(self):
         with self.assertRaises(SystemExit):
@@ -280,7 +286,7 @@ class Parsing(TestCase):
         ))
 
     def test_cfg_team_no_name(self):
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ValueError):
             parse_cli_args([str(self.problem_path), f"--config={self.configs_path / 'teams_incorrect.toml'}"])
 
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -45,7 +45,7 @@ class Matchtests(TestCase):
     def test_calculate_points_zero_rounds(self):
         """All teams get 0 points if no rounds have been fought."""
         match = Match(MatchConfig(rounds=0), Iterated.Config(), TestProblem, self.teams)
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 0, self.team1.name: 0})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 0, self.team1.name: 0})
 
     def test_calculate_points_iterated_no_successful_round(self):
         """Two teams should get an equal amount of points if nobody solved anything."""
@@ -54,7 +54,7 @@ class Matchtests(TestCase):
         battle.reached = 0
         match.results[self.matchup0] = [battle, battle]
         match.results[self.matchup1] = [battle, battle]
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 50, self.team1.name: 50})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 50, self.team1.name: 50})
 
     def test_calculate_points_iterated_draw(self):
         """Two teams should get an equal amount of points if both solved a problem equally well."""
@@ -65,7 +65,7 @@ class Matchtests(TestCase):
         battle2.reached = 10
         match.results[self.matchup0] = [battle, battle2]
         match.results[self.matchup1] = [battle2, battle]
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 50, self.team1.name: 50})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 50, self.team1.name: 50})
 
     def test_calculate_points_iterated_domination(self):
         """One team should get all points if it solved anything and the other team nothing."""
@@ -76,7 +76,7 @@ class Matchtests(TestCase):
         battle2.reached = 0
         match.results[self.matchup0] = [battle, battle]
         match.results[self.matchup1] = [battle2, battle2]
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 0, self.team1.name: 100})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 0, self.team1.name: 100})
 
     def test_calculate_points_iterated_one_team_better(self):
         """One team should get more points than the other if it performed better."""
@@ -87,7 +87,7 @@ class Matchtests(TestCase):
         battle2.reached = 20
         match.results[self.matchup0] = [battle, battle]
         match.results[self.matchup1] = [battle2, battle2]
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 66.6, self.team1.name: 33.4})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 66.6, self.team1.name: 33.4})
 
     def test_calculate_points_averaged_no_successful_round(self):
         """Two teams should get an equal amount of points if nobody solved anything."""
@@ -96,7 +96,7 @@ class Matchtests(TestCase):
         battle.scores = [0, 0, 0]
         match.results[self.matchup0] = [battle, battle]
         match.results[self.matchup1] = [battle, battle]
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 50, self.team1.name: 50})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 50, self.team1.name: 50})
 
     def test_calculate_points_averaged_draw(self):
         """Two teams should get an equal amount of points if both solved a problem equally well."""
@@ -105,7 +105,7 @@ class Matchtests(TestCase):
         battle.scores = [.5, .5, .5]
         match.results[self.matchup0] = [battle, battle]
         match.results[self.matchup1] = [battle, battle]
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 50, self.team1.name: 50})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 50, self.team1.name: 50})
 
     def test_calculate_points_averaged_domination(self):
         """One team should get all points if it solved anything and the other team nothing."""
@@ -116,7 +116,7 @@ class Matchtests(TestCase):
         battle2.scores = [1, 1, 1]
         match.results[self.matchup0] = [battle, battle]
         match.results[self.matchup1] = [battle2, battle2]
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 100, self.team1.name: 0})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 100, self.team1.name: 0})
 
     def test_calculate_points_averaged_one_team_better(self):
         """One team should get more points than the other if it performed better."""
@@ -127,7 +127,7 @@ class Matchtests(TestCase):
         battle2.scores = [.4, .4, .4]
         match.results[self.matchup0] = [battle, battle]
         match.results[self.matchup1] = [battle2, battle2]
-        self.assertEqual(match.calculate_points(100), {self.team0.name: 60, self.team1.name: 40})
+        self.assertEqual(match.calculate_points(), {self.team0.name: 60, self.team1.name: 40})
 
     # TODO: Add tests for remaining functions
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -4,7 +4,7 @@ from unittest import TestCase, main
 import logging
 from pathlib import Path
 
-from algobattle.cli import Config, parse_cli_args, setup_logging
+from algobattle.cli import Config, ExecutionConfig, parse_cli_args, setup_logging
 from algobattle.battle import Iterated, Averaged
 from algobattle.match import MatchConfig, Match
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo
@@ -211,10 +211,10 @@ class Parsing(TestCase):
         self.assertEqual(cfg, Config(
             match=MatchConfig(
                 points=10,
-                safe_build=True,
                 battle_type=Averaged,
             ),
             teams=self.teams,
+            execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
         ))
         self.assertEqual(battle_cfg, Averaged.Config(iterations=1))
@@ -234,10 +234,10 @@ class Parsing(TestCase):
         self.assertEqual(cfg, Config(
             match=MatchConfig(
                 points=10,
-                safe_build=True,
                 battle_type=Averaged,
             ),
             teams=self.teams,
+            execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
         ))
         self.assertEqual(battle_cfg, Averaged.Config(iterations=1))
@@ -257,10 +257,10 @@ class Parsing(TestCase):
         self.assertEqual(cfg, Config(
             match=MatchConfig(
                 points=20,
-                safe_build=True,
                 battle_type=Iterated,
             ),
             teams=self.teams,
+            execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
         ))
         self.assertEqual(battle_cfg, Iterated.Config())


### PR DESCRIPTION
Previously we used pydantic to parse some of the config settings and did some manually, this just changes it all to use pydantic parsing. This makes it much more reliable, easier to use, and gives us much better error handling.