### PR TITLE
Replace logging messages with match object serialization

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -2,8 +2,7 @@
 
 The battle class is a base class for specific type of battle that can be executed.
 """
-from dataclasses import dataclass, field
-from datetime import datetime
+from dataclasses import dataclass
 from importlib.metadata import entry_points
 from abc import abstractmethod
 from typing import (
@@ -173,13 +172,14 @@ class BattleUiProxy(Protocol):
 class Battle(BaseModel):
     """Abstract Base class for classes that execute a specific kind of battle."""
 
-    fight_results: list[Fight] = field(default_factory=list)
+    fight_results: list[Fight] = Field(default_factory=list)
     run_exception: Exception | str | None = None
 
     _battle_types: ClassVar[dict[str, type["Battle"]]] = {}
 
     class Config(BaseModel.Config):
 
+        arbitrary_types_allowed = True
         json_encoders = {
             Exception: str_with_traceback,
         }
@@ -254,11 +254,10 @@ class Battle(BaseModel):
         }
 
 
-@dataclass
 class Iterated(Battle):
     """Class that executes an iterated battle."""
 
-    results: list[int] = field(default_factory=list)
+    results: list[int] = Field(default_factory=list)
 
     @inherit_docs
     class BattleConfig(Battle.BattleConfig):
@@ -336,7 +335,6 @@ class Iterated(Battle):
         return str(int(score))
 
 
-@dataclass
 class Averaged(Battle):
     """Class that executes an averaged battle."""
 

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -37,6 +37,15 @@ _Config: TypeAlias = Any
 T = TypeVar("T")
 
 
+class Fight(BaseModel):
+    """The result of one execution of the generator and the solver with the generated instance."""
+
+    score: float
+    size: int
+    generator: GeneratorResult
+    solver: SolverResult | None
+
+
 class FightUiProxy(Protocol):
     """Provides an interface for :cls:`Fight` to update the Ui."""
 
@@ -96,7 +105,7 @@ class FightHandler:
         solver_battle_input: Mapping[str, Encodable] = {},
         generator_battle_output: Mapping[str, type[Encodable]] = {},
         solver_battle_output: Mapping[str, type[Encodable]] = {},
-    ) -> "Fight":
+    ) -> Fight:
         """Execute a single fight of a battle between the given programs."""
         ui = self._ui.fight_ui
         ui.start(size)
@@ -135,15 +144,6 @@ class FightHandler:
         self._battle.fight_results.append(result)
         self._ui.update_fights()
         return result
-
-
-class Fight(BaseModel):
-    """The result of one execution of the generator and the solver with the generated instance."""
-
-    score: float
-    size: int
-    generator: GeneratorResult
-    solver: SolverResult | None
 
 
 @dataclass

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -19,7 +19,7 @@ from typing import (
     overload,
 )
 
-from pydantic import Field, BaseConfig, validator
+from pydantic import Field
 
 from algobattle.docker_util import (
     ProgramError,

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -19,7 +19,7 @@ from typing import (
     overload,
 )
 
-from pydantic import Field, BaseConfig
+from pydantic import Field, BaseConfig, validator
 
 from algobattle.docker_util import (
     ProgramError,
@@ -175,7 +175,7 @@ class Battle(BaseModel):
     """Abstract Base class for classes that execute a specific kind of battle."""
 
     fight_results: list[Fight] = field(default_factory=list)
-    run_exception: Exception | None = None
+    run_exception: Exception | str | None = None
 
     _battle_types: ClassVar[dict[str, type["Battle"]]] = {}
 
@@ -219,7 +219,7 @@ class Battle(BaseModel):
     def __init_subclass__(cls) -> None:
         if cls.name() not in Battle._battle_types:
             Battle._battle_types[cls.name().lower()] = cls
-        return super().__init_subclass__()
+        return super().__init_subclass__()       
 
     @abstractmethod
     def score(self) -> float:

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -211,7 +211,7 @@ class Battle(BaseModel):
     def __init_subclass__(cls) -> None:
         if cls.name() not in Battle._battle_types:
             Battle._battle_types[cls.name().lower()] = cls
-        return super().__init_subclass__()       
+        return super().__init_subclass__()
 
     @abstractmethod
     def score(self) -> float:
@@ -235,10 +235,7 @@ class Battle(BaseModel):
 
     def archive(self) -> dict[str, Any]:
         """Encodes the battle data into a jsonable dict."""
-
-        return {
-            "run_exception": self.run_exception
-        }
+        return {"run_exception": self.run_exception}
 
 
 class Iterated(Battle):

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -57,12 +57,12 @@ class FightUiProxy(Protocol):
 
     @overload
     @abstractmethod
-    def update(self, role: Literal["generator"], data: datetime | float | GeneratorResult | None) -> None:
+    def update(self, role: Literal["generator"], data: GeneratorResult) -> None:
         ...
 
     @overload
     @abstractmethod
-    def update(self, role: Literal["solver"], data: datetime | float | SolverResult | None) -> None:
+    def update(self, role: Literal["solver"], data: SolverResult) -> None:
         ...
 
     @overload
@@ -74,7 +74,7 @@ class FightUiProxy(Protocol):
     def update(
         self,
         role: Role | None = None,
-        data: datetime | float | ProgramResult | None = None,
+        data: ProgramResult | None = None,
     ) -> None:
         """Updates the ui with info about the current fight.
 

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -53,12 +53,7 @@ class FightUiProxy(Protocol):
 
     @overload
     @abstractmethod
-    def update(self, role: Literal["generator"], data: ProgramRunInfo) -> None:
-        ...
-
-    @overload
-    @abstractmethod
-    def update(self, role: Literal["solver"], data: ProgramRunInfo) -> None:
+    def update(self, role: Literal["generator", "solver"], data: ProgramRunInfo) -> None:
         ...
 
     @overload

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -26,7 +26,7 @@ from algobattle.docker_util import (
     ProgramUiProxy,
     Solver,
 )
-from algobattle.util import Encodable, Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
+from algobattle.util import Encodable, Role, TimerInfo, inherit_docs, BaseModel
 
 
 _Config: TypeAlias = Any

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -167,16 +167,9 @@ class Battle(BaseModel):
     """Abstract Base class for classes that execute a specific kind of battle."""
 
     fight_results: list[Fight] = Field(default_factory=list)
-    run_exception: Exception | str | None = None
+    run_exception: str | None = None
 
     _battle_types: ClassVar[dict[str, type["Battle"]]] = {}
-
-    class Config(BaseModel.Config):
-
-        arbitrary_types_allowed = True
-        json_encoders = {
-            Exception: str_with_traceback,
-        }
 
     class BattleConfig(BaseModel):
         """Object containing the config variables the battle types use."""

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -131,14 +131,13 @@ class FightHandler:
             solution=sol_result.result, generator_solution=gen_result.result.solution, size=size
         )
         score = max(0, min(1, float(score)))
-        result = Fight(score, size, gen_result, sol_result)
+        result = Fight(score=score, size=size, generator=gen_result, solver=sol_result)
         self._battle.fight_results.append(result)
         self._ui.update_fights()
         return result
 
 
-@dataclass
-class Fight:
+class Fight(BaseModel):
     """The result of one execution of the generator and the solver with the generated instance."""
 
     score: float

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -30,7 +30,7 @@ from algobattle.docker_util import (
     GeneratorResult,
     SolverResult,
 )
-from algobattle.util import Encodable, Role, TimerInfo, inherit_docs, BaseModel
+from algobattle.util import Encodable, Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
 
 
 _Config: TypeAlias = Any
@@ -177,6 +177,12 @@ class Battle(BaseModel):
     run_exception: Exception | str | None = None
 
     _battle_types: ClassVar[dict[str, type["Battle"]]] = {}
+
+    class Config(BaseModel.Config):
+
+        json_encoders = {
+            Exception: str_with_traceback,
+        }
 
     class BattleConfig(BaseModel):
         """Object containing the config variables the battle types use."""

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -87,6 +87,11 @@ class FightHandler:
     _battle: "Battle"
     _ui: "BattleUiProxy"
 
+    def _saved(self, fight: Fight) -> Fight:
+        self._battle.fight_results.append(fight)
+        self._ui.update_fights()
+        return fight
+
     async def run(
         self,
         size: int,
@@ -116,7 +121,7 @@ class FightHandler:
         )
         ui.update("generator", gen_result.info)
         if gen_result.instance is None:
-            return Fight(score=1, size=size, generator=gen_result.info, solver=None)
+            return self._saved(Fight(score=1, size=size, generator=gen_result.info, solver=None))
 
         sol_result = await self._solver.run(
             gen_result.instance,
@@ -130,16 +135,13 @@ class FightHandler:
         )
         ui.update("solver", sol_result.info)
         if sol_result.solution is None:
-            return Fight(score=0, size=size, generator=gen_result.info, solver=sol_result.info)
+            return self._saved(Fight(score=0, size=size, generator=gen_result.info, solver=sol_result.info))
 
         score = gen_result.instance.calculate_score(
             solution=sol_result.solution, generator_solution=gen_result.solution, size=size
         )
         score = max(0, min(1, float(score)))
-        result = Fight(score=score, size=size, generator=gen_result.info, solver=sol_result.info)
-        self._battle.fight_results.append(result)
-        self._ui.update_fights()
-        return result
+        return self._saved(Fight(score=score, size=size, generator=gen_result.info, solver=sol_result.info))
 
 
 @dataclass

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -5,7 +5,6 @@ The battle class is a base class for specific type of battle that can be execute
 from dataclasses import dataclass, field
 from datetime import datetime
 from importlib.metadata import entry_points
-import logging
 from abc import abstractmethod, ABC
 from typing import (
     Any,
@@ -32,8 +31,6 @@ from algobattle.docker_util import (
     SolverResult,
 )
 from algobattle.util import Encodable, Role, TimerInfo, inherit_docs
-
-logger = logging.getLogger("algobattle.battle")
 
 
 _Config: TypeAlias = Any
@@ -133,7 +130,6 @@ class FightHandler:
             solution=sol_result.result, generator_solution=gen_result.result.solution, size=size
         )
         score = max(0, min(1, float(score)))
-        logger.info(f"The solver achieved a score of {score}.")
         result = Fight(score, size, gen_result, sol_result)
         self._battle.fight_results.append(result)
         self._battle.ui.update_fights()
@@ -295,15 +291,10 @@ class Iterated(Battle):
                 result = await fight.run(current)
                 score = result.score
                 if score < config.approximation_ratio:
-                    logger.info(
-                        f"Solver does not meet the required solution quality at instance size "
-                        f"{current}. ({score}/{config.approximation_ratio})"
-                    )
                     alive = False
 
                 if not alive and base_increment > 1:
                     # The step size increase was too aggressive, take it back and reset the base_increment
-                    logger.info(f"Setting the solution cap to {current}...")
                     cap = current
                     current -= base_increment**config.exponent
                     base_increment = 0

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -176,6 +176,7 @@ class Battle(ABC):
 
     ui: BattleUiProxy
     fight_results: list[Fight] = field(default_factory=list)
+    run_exception: Exception | None = field(default=None, init=False)
 
     scoring_team: ClassVar[Role] = "solver"
     _battle_types: ClassVar[dict[str, type["Battle"]]] = {}

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -178,7 +178,6 @@ class Battle(ABC):
     fight_results: list[Fight] = field(default_factory=list)
     run_exception: Exception | None = field(default=None, init=False)
 
-    scoring_team: ClassVar[Role] = "solver"
     _battle_types: ClassVar[dict[str, type["Battle"]]] = {}
 
     class Config(BaseModel):

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -323,7 +323,11 @@ class CliUi(Ui):
         table.align["Result"] = "r"
 
         for matchup, result in match.results.items():
-            table.add_row([str(matchup.generator), str(matchup.solver), result.format_score(result.score())])
+            if result.run_exception is None:
+                res = result.format_score(result.score())
+            else:
+                res = f"Error: {result.run_exception}"
+            table.add_row([str(matchup.generator), str(matchup.solver), res])
 
         return [f"Battle Type: {match.config.battle_type.name()}"] + list(str(table).split("\n"))
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -16,7 +16,7 @@ from pydantic import validator
 from anyio import create_task_group, run, sleep
 
 from algobattle.battle import Battle, Fight, FightUiData
-from algobattle.docker_util import DockerConfig, GeneratorResult, Image, ProgramError, ProgramRunInfo, SolverResult
+from algobattle.docker_util import DockerConfig, GeneratorResult, Image, ProgramRunInfo, SolverResult
 from algobattle.match import MatchConfig, Match, Ui
 from algobattle.problem import Problem
 from algobattle.team import Matchup, TeamHandler, TeamInfo

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -379,7 +379,7 @@ class CliUi(Ui):
     @staticmethod
     def display_fight(fight: Fight, index: int) -> list[str]:
         """Formats a completed fight into a compact overview."""
-        out = [f"Fight {index} at size {fight.generator.size}:"]
+        out = [f"Fight {index} at size {fight.size}:"]
         if fight.generator.error is not None:
             out.append("Generator failed!")
             return out

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -404,7 +404,7 @@ class Image:
 class ProgramResult(BaseModel):
     """Result of a program execution."""
 
-    result: "Any | Problem.Solution | ProgramError"
+    result: "GeneratorResult.Data | Problem.Solution | ProgramError"
     runtime: float
     size: int
     params: RunParameters

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -379,7 +379,7 @@ class Image:
             elapsed_time = round(default_timer() - start_time, 2)
             if len(e.args) != 1 or not isinstance(e.args[0], ReadTimeoutError):
                 raise
-            raise ExecutionTimeout(f"The docker container exceeded the time limit.", runtime=elapsed_time)
+            raise ExecutionTimeout("The docker container exceeded the time limit.", runtime=elapsed_time)
 
 
 class ProgramRunInfo(BaseModel):
@@ -600,9 +600,9 @@ class Generator(Program):
         except EncodingError:
             raise
         except Exception as e:
-            raise EncodingError(f"Error thrown while decoding the problem instance.", detail=str(e)) from e
+            raise EncodingError("Error thrown while decoding the problem instance.", detail=str(e)) from e
         if not problem.is_valid(size):
-            raise EncodingError(f"Instance is not valid.")
+            raise EncodingError("Instance is not valid.")
 
         if problem.with_solution:
             try:

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -2,7 +2,7 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 from timeit import default_timer
-from typing import Any, ClassVar, Iterator, Literal, Mapping, Protocol, Self, TypeAlias, TypedDict, cast
+from typing import Any, ClassVar, Iterator, Literal, Mapping, Protocol, Self, TypedDict, cast
 from uuid import uuid1
 import json
 from dataclasses import dataclass
@@ -13,7 +13,7 @@ from docker.models.images import Image as DockerImage
 from docker.models.containers import Container as DockerContainer
 from docker.types import Mount, LogConfig, Ulimit
 from requests import Timeout, ConnectionError
-from pydantic import Field, PrivateAttr, validator
+from pydantic import Field
 from anyio.to_thread import run_sync
 from urllib3.exceptions import ReadTimeoutError
 

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -13,11 +13,11 @@ from docker.models.images import Image as DockerImage
 from docker.models.containers import Container as DockerContainer
 from docker.types import Mount, LogConfig, Ulimit
 from requests import Timeout, ConnectionError
-from pydantic import BaseModel, Field
+from pydantic import Field
 from anyio.to_thread import run_sync
 from urllib3.exceptions import ReadTimeoutError
 
-from algobattle.util import Encodable, Role, TempDir, encode, decode, inherit_docs
+from algobattle.util import Encodable, Role, TempDir, encode, decode, inherit_docs, BaseModel
 from algobattle.problem import Problem
 
 

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -409,6 +409,8 @@ class ProgramRunInfo(BaseModel):
     error: ProgramError | None = None
 
     class Config(BaseModel.Config):
+        """Pydantic config."""
+
         arbitrary_types_allowed = True
         json_encoders = {
             ProgramError: lambda e: e.jsonify(),
@@ -417,7 +419,7 @@ class ProgramRunInfo(BaseModel):
 
 @dataclass
 class ProgramResult:
-    """The result of a program execution"""
+    """The result of a program execution."""
 
     info: ProgramRunInfo
     battle_data: dict[str, Encodable] | None = None
@@ -529,37 +531,45 @@ class Program(ABC):
                 try:
                     encode(battle_input, input / "battle_data", size, self.role)
                 except Exception as e:
-                    return result_class(ProgramRunInfo(
-                        params=run_params,
-                        runtime=0,
-                        error=EncodingError(f"Battle data couldn't be encoded:\n{e}"),
-                    ))
+                    return result_class(
+                        ProgramRunInfo(
+                            params=run_params,
+                            runtime=0,
+                            error=EncodingError(f"Battle data couldn't be encoded:\n{e}"),
+                        )
+                    )
             if battle_output:
                 (output / "battle_data").mkdir()
 
             try:
                 runtime = await self.image.run(input, output, timeout=timeout, memory=space, cpus=cpus, ui=ui)
             except ExecutionError as e:
-                return result_class(ProgramRunInfo(
-                    params=run_params,
-                    runtime=e.runtime,
-                    error=e,
-                ))
+                return result_class(
+                    ProgramRunInfo(
+                        params=run_params,
+                        runtime=e.runtime,
+                        error=e,
+                    )
+                )
             except ProgramError as e:
-                return result_class(ProgramRunInfo(
-                    params=run_params,
-                    runtime=0,
-                    error=e,
-                ))
+                return result_class(
+                    ProgramRunInfo(
+                        params=run_params,
+                        runtime=0,
+                        error=e,
+                    )
+                )
 
             try:
                 output_data = self._parse_output(output, size, input_instance)
             except ProgramError as e:
-                return result_class(ProgramRunInfo(
-                    params=run_params,
-                    runtime=runtime,
-                    error=e,
-                ))
+                return result_class(
+                    ProgramRunInfo(
+                        params=run_params,
+                        runtime=runtime,
+                        error=e,
+                    )
+                )
 
             if battle_output:
                 decoded_battle_output = decode(battle_output, output / "battle_data", size, self.role)
@@ -627,7 +637,9 @@ class Generator(Program):
             except EncodingError:
                 raise
             except Exception as e:
-                raise EncodingError(f"The solution output of team {self.team_name}'s generator can not be decoded properly!\n{e}") from e
+                raise EncodingError(
+                    f"The solution output of team {self.team_name}'s generator can not be decoded properly!\n{e}"
+                ) from e
             if not solution.is_valid(problem, size):
                 raise EncodingError(f"The generator of team {self.team_name} output an invalid solution!")
         else:

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -404,7 +404,6 @@ class Image:
 class ProgramRunInfo(BaseModel):
     """Metadata about a program execution."""
 
-    size: int
     params: RunParameters
     runtime: float
     error: ProgramError | None = None
@@ -512,7 +511,7 @@ class Program(ABC):
             try:
                 self._setup_folders(input, output, size, input_instance)
             except ProgramError as e:
-                return result_class(ProgramRunInfo(size=size, params=run_params, runtime=0, error=e))
+                return result_class(ProgramRunInfo(params=run_params, runtime=0, error=e))
             with open(input / "info.json", "w+") as f:
                 json.dump(
                     {
@@ -531,7 +530,6 @@ class Program(ABC):
                     encode(battle_input, input / "battle_data", size, self.role)
                 except Exception as e:
                     return result_class(ProgramRunInfo(
-                        size=size,
                         params=run_params,
                         runtime=0,
                         error=EncodingError(f"Battle data couldn't be encoded:\n{e}"),
@@ -543,14 +541,12 @@ class Program(ABC):
                 runtime = await self.image.run(input, output, timeout=timeout, memory=space, cpus=cpus, ui=ui)
             except ExecutionError as e:
                 return result_class(ProgramRunInfo(
-                    size=size,
                     params=run_params,
                     runtime=e.runtime,
                     error=e,
                 ))
             except ProgramError as e:
                 return result_class(ProgramRunInfo(
-                    size=size,
                     params=run_params,
                     runtime=0,
                     error=e,
@@ -560,7 +556,6 @@ class Program(ABC):
                 output_data = self._parse_output(output, size, input_instance)
             except ProgramError as e:
                 return result_class(ProgramRunInfo(
-                    size=size,
                     params=run_params,
                     runtime=runtime,
                     error=e,
@@ -574,7 +569,6 @@ class Program(ABC):
         if isinstance(output_data, _GenResData):
             return GeneratorResult(
                 ProgramRunInfo(
-                    size=size,
                     params=run_params,
                     runtime=runtime,
                 ),
@@ -585,7 +579,6 @@ class Program(ABC):
         else:
             return SolverResult(
                 ProgramRunInfo(
-                    size=size,
                     params=run_params,
                     runtime=runtime,
                 ),

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -11,7 +11,7 @@ from anyio.to_thread import current_default_thread_limiter
 from anyio.abc import TaskStatus
 
 from algobattle.battle import Battle, FightHandler, FightUiProxy, Iterated, BattleUiProxy
-from algobattle.docker_util import GeneratorResult, ProgramUiProxy, SolverResult
+from algobattle.docker_util import GeneratorResult, ProgramRunInfo, ProgramUiProxy, SolverResult
 from algobattle.team import Matchup, TeamHandler
 from algobattle.problem import Problem
 from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel
@@ -75,8 +75,8 @@ class Match(BaseModel):
                     problem.min_size,
                     battle_ui,
                 )
-            except Exception as e:
-                battle.run_exception = e
+            #except Exception as e:
+            #    battle.run_exception = e
             finally:
                 ui.battle_completed(matchup)
 
@@ -186,7 +186,7 @@ class Ui:
         self,
         matchup: Matchup,
         role: Role | None = None,
-        data: TimerInfo | float | GeneratorResult | SolverResult | None = None,
+        data: TimerInfo | float | ProgramRunInfo | None = None,
     ) -> None:
         """Passes new info about the current fight to the Ui."""
         return
@@ -234,7 +234,7 @@ class Ui:
         def update(
             self,
             role: Role | None = None,
-            data: TimerInfo | float | GeneratorResult | SolverResult | None = None,
+            data: TimerInfo | float | ProgramRunInfo | None = None,
         ) -> None:
             self.battle_ui.ui.update_curr_fight(self.battle_ui.matchup, role, data)
 

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -110,8 +110,6 @@ class Match:
         points_per_battle = round(achievable_points / (len(self.teams.active) - 1), 1)
 
         for home_matchup, away_matchup in self.teams.grouped_matchups:
-            home_team: Team = getattr(home_matchup, self.config.battle_type.scoring_team)
-            away_team: Team = getattr(away_matchup, self.config.battle_type.scoring_team)
             try:
                 home_res = self.results[home_matchup]
                 away_res = self.results[away_matchup]
@@ -126,8 +124,8 @@ class Match:
                 home_ratio = home_res.score() / total_score
                 away_ratio = away_res.score() / total_score
 
-            points[home_team.name] += round(points_per_battle * home_ratio, 1)
-            points[away_team.name] += round(points_per_battle * away_ratio, 1)
+            points[home_matchup.solver.name] += round(points_per_battle * home_ratio, 1)
+            points[away_matchup.solver.name] += round(points_per_battle * away_ratio, 1)
 
         # we need to also add the points each team would have gotten fighting the excluded teams
         # each active team would have had one set of battles against each excluded team

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -38,10 +38,17 @@ class MatchConfig(BaseModel):
         else:
             raise TypeError
 
+    class Config(BaseModel.Config):
+
+        json_encoders = {
+            type[Battle]: lambda b: b.name().lower(),
+        }
+
 
 class Match(BaseModel):
     """The Result of a whole Match."""
 
+    config: MatchConfig
     active_teams: list[str]
     excluded_teams: list[str]
     results: defaultdict[str, dict[str, Battle]] = field(default_factory=lambda: defaultdict(dict), init=False)
@@ -84,7 +91,10 @@ class Match(BaseModel):
         ui: "Ui | None" = None,
     ) -> Self:
         """Executes a match with the specified parameters."""
-        result = cls(active_teams=[t.name for t in teams.active], excluded_teams=[t.name for t in teams.excluded])
+        result = cls(
+            config=config,
+            active_teams=[t.name for t in teams.active], excluded_teams=[t.name for t in teams.excluded],
+        )
         if ui is None:
             ui = Ui()
         ui.match = result
@@ -97,12 +107,13 @@ class Match(BaseModel):
                 await tg.start(result._run_battle, battle, matchup, battle_config, problem, ui, limiter)
             return result
 
-    def calculate_points(self, points_per_matchup: int) -> dict[str, float]:
+    def calculate_points(self) -> dict[str, float]:
         """Calculate the number of points each team scored.
 
         Each pair of teams fights for the achievable points among one another.
         These achievable points are split over all rounds.
         """
+        points_per_matchup = self.config.points
         if len(self.active_teams) == 0:
             return {}
         if len(self.active_teams) == 1:

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -132,9 +132,10 @@ class Match(BaseModel):
         """Returns the battle for the given matchup."""
         if matchup is not None:
             self.results[matchup.generator.name][matchup.solver.name] = battle
-        if generating is not None and solving is not None:
+        elif generating is not None and solving is not None:
             self.results[generating.name][solving.name] = battle
-        raise TypeError
+        else:
+            raise TypeError
 
     def calculate_points(self, points_per_matchup: int) -> dict[str, float]:
         """Calculate the number of points each team scored.

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -14,7 +14,7 @@ from algobattle.battle import Battle, FightHandler, FightUiProxy, Iterated, Batt
 from algobattle.docker_util import ProgramRunInfo, ProgramUiProxy
 from algobattle.team import Matchup, TeamHandler
 from algobattle.problem import Problem
-from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel
+from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
 
 
 class MatchConfig(BaseModel):
@@ -75,8 +75,8 @@ class Match(BaseModel):
                     problem.min_size,
                     battle_ui,
                 )
-            #except Exception as e:
-            #    battle.run_exception = e
+            except Exception as e:
+                battle.run_exception = str_with_traceback(e)
             finally:
                 ui.battle_completed(matchup)
 

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -11,7 +11,7 @@ from anyio.to_thread import current_default_thread_limiter
 from anyio.abc import TaskStatus
 
 from algobattle.battle import Battle, FightHandler, FightUiProxy, Iterated, BattleUiProxy
-from algobattle.docker_util import GeneratorResult, ProgramRunInfo, ProgramUiProxy, SolverResult
+from algobattle.docker_util import ProgramRunInfo, ProgramUiProxy
 from algobattle.team import Matchup, TeamHandler
 from algobattle.problem import Problem
 from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -1,7 +1,6 @@
 """Central managing module for an algorithmic battle."""
 from dataclasses import dataclass, field
 from datetime import datetime
-import logging
 from typing import Self
 
 from pydantic import BaseModel, validator
@@ -14,8 +13,6 @@ from algobattle.docker_util import GeneratorResult, ProgramUiProxy, SolverResult
 from algobattle.team import Matchup, TeamHandler, Team
 from algobattle.problem import Problem
 from algobattle.util import Role, TimerInfo, inherit_docs
-
-logger = logging.getLogger("algobattle.match")
 
 
 class MatchConfig(BaseModel):
@@ -76,8 +73,9 @@ class Match:
                     self.battle_config,
                     self.problem.min_size,
                 )
-            except Exception as e:
-                logger.critical(f"Unhandeled error during execution of battle!\n{e}")
+            except Exception as _:
+                #! Add some useful error logging schema here
+                pass
             finally:
                 ui.battle_completed(matchup)
 

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from itertools import combinations
 from typing import Self
 
-from pydantic import BaseModel, validator
+from pydantic import validator
 from anyio import create_task_group, CapacityLimiter, TASK_STATUS_IGNORED
 from anyio.to_thread import current_default_thread_limiter
 from anyio.abc import TaskStatus
@@ -14,7 +14,7 @@ from algobattle.battle import Battle, FightHandler, FightUiProxy, Iterated, Batt
 from algobattle.docker_util import GeneratorResult, ProgramUiProxy, SolverResult
 from algobattle.team import Matchup, TeamHandler
 from algobattle.problem import Problem
-from algobattle.util import Role, TimerInfo, inherit_docs
+from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel
 
 
 class MatchConfig(BaseModel):
@@ -50,7 +50,7 @@ class Match(BaseModel):
         self,
         battle: Battle,
         matchup: Matchup,
-        config: Battle.Config,
+        config: Battle.BattleConfig,
         problem: type[Problem],
         ui: "Ui",
         limiter: CapacityLimiter,
@@ -78,7 +78,7 @@ class Match(BaseModel):
     async def run(
         cls,
         config: MatchConfig,
-        battle_config: Battle.Config,
+        battle_config: Battle.BattleConfig,
         problem: type[Problem],
         teams: TeamHandler,
         ui: "Ui | None" = None,

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -39,6 +39,7 @@ class MatchConfig(BaseModel):
             raise TypeError
 
     class Config(BaseModel.Config):
+        """Pydantic config."""
 
         json_encoders = {
             type[Battle]: lambda b: b.name().lower(),
@@ -91,7 +92,8 @@ class Match(BaseModel):
     ) -> Self:
         """Executes a match with the specified parameters."""
         result = cls(
-            active_teams=[t.name for t in teams.active], excluded_teams=[t.name for t in teams.excluded],
+            active_teams=[t.name for t in teams.active],
+            excluded_teams=[t.name for t in teams.excluded],
         )
         if ui is None:
             ui = Ui()
@@ -106,12 +108,16 @@ class Match(BaseModel):
             return result
 
     @overload
-    def battle(self, matchup: Matchup) -> Battle | None: ...
+    def battle(self, matchup: Matchup) -> Battle | None:
+        ...
 
     @overload
-    def battle(self, *, generating: Team, solving: Team) -> Battle | None: ...
+    def battle(self, *, generating: Team, solving: Team) -> Battle | None:
+        ...
 
-    def battle(self, matchup: Matchup | None = None, *, generating: Team | None = None, solving: Team | None = None) -> Battle | None:
+    def battle(
+        self, matchup: Matchup | None = None, *, generating: Team | None = None, solving: Team | None = None
+    ) -> Battle | None:
         """Returns the battle for the given matchup."""
         try:
             if matchup is not None:
@@ -123,12 +129,16 @@ class Match(BaseModel):
             return None
 
     @overload
-    def insert_battle(self, battle: Battle, matchup: Matchup) -> Battle | None: ...
+    def insert_battle(self, battle: Battle, matchup: Matchup) -> Battle | None:
+        ...
 
     @overload
-    def insert_battle(self, battle: Battle, *, generating: Team, solving: Team) -> Battle | None: ...
+    def insert_battle(self, battle: Battle, *, generating: Team, solving: Team) -> Battle | None:
+        ...
 
-    def insert_battle(self, battle: Battle, matchup: Matchup | None = None, *, generating: Team | None = None, solving: Team | None = None) -> Battle | None:
+    def insert_battle(
+        self, battle: Battle, matchup: Matchup | None = None, *, generating: Team | None = None, solving: Team | None = None
+    ) -> Battle | None:
         """Returns the battle for the given matchup."""
         if matchup is not None:
             self.results[matchup.generator.name][matchup.solver.name] = battle

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -106,18 +106,21 @@ class Match(BaseModel):
             return result
 
     @overload
-    def battle(self, matchup: Matchup) -> Battle: ...
+    def battle(self, matchup: Matchup) -> Battle | None: ...
 
     @overload
-    def battle(self, *, generating: Team, solving: Team) -> Battle: ...
+    def battle(self, *, generating: Team, solving: Team) -> Battle | None: ...
 
-    def battle(self, matchup: Matchup | None = None, *, generating: Team | None = None, solving: Team | None = None) -> Battle:
+    def battle(self, matchup: Matchup | None = None, *, generating: Team | None = None, solving: Team | None = None) -> Battle | None:
         """Returns the battle for the given matchup."""
-        if matchup is not None:
-            return self.results[matchup.generator.name][matchup.solver.name]
-        if generating is not None and solving is not None:
-            return self.results[generating.name][solving.name]
-        raise TypeError
+        try:
+            if matchup is not None:
+                return self.results[matchup.generator.name][matchup.solver.name]
+            if generating is not None and solving is not None:
+                return self.results[generating.name][solving.name]
+            raise TypeError
+        except KeyError:
+            return None
 
     def calculate_points(self, points_per_matchup: int) -> dict[str, float]:
         """Calculate the number of points each team scored.

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -122,6 +122,20 @@ class Match(BaseModel):
         except KeyError:
             return None
 
+    @overload
+    def insert_battle(self, battle: Battle, matchup: Matchup) -> Battle | None: ...
+
+    @overload
+    def insert_battle(self, battle: Battle, *, generating: Team, solving: Team) -> Battle | None: ...
+
+    def insert_battle(self, battle: Battle, matchup: Matchup | None = None, *, generating: Team | None = None, solving: Team | None = None) -> Battle | None:
+        """Returns the battle for the given matchup."""
+        if matchup is not None:
+            self.results[matchup.generator.name][matchup.solver.name] = battle
+        if generating is not None and solving is not None:
+            self.results[generating.name][solving.name] = battle
+        raise TypeError
+
     def calculate_points(self, points_per_matchup: int) -> dict[str, float]:
         """Calculate the number of points each team scored.
 

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -37,22 +37,15 @@ class MatchConfig(BaseModel):
             raise TypeError
 
 
+@dataclass
 class Match:
     """The Result of a whole Match."""
 
-    def __init__(
-        self,
-        config: MatchConfig,
-        battle_config: Battle.Config,
-        problem: type[Problem],
-        teams: TeamHandler,
-    ) -> None:
-        self.results: dict[Matchup, Battle] = {}
-        self.config = config
-        self.battle_config = battle_config
-        self.problem = problem
-        self.teams = teams
-        super().__init__()
+    config: MatchConfig
+    battle_config: Battle.Config
+    problem: type[Problem]
+    teams: TeamHandler
+    results: dict[Matchup, Battle] = field(default_factory=dict, init=False)
 
     async def _run_battle(
         self,
@@ -73,9 +66,8 @@ class Match:
                     self.battle_config,
                     self.problem.min_size,
                 )
-            except Exception as _:
-                #! Add some useful error logging schema here
-                pass
+            except Exception as e:
+                battle.run_exception = e
             finally:
                 ui.battle_completed(matchup)
 

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -2,15 +2,12 @@
 from abc import ABC, abstractmethod
 import importlib.util
 from inspect import isclass
-import logging
 import sys
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Protocol, SupportsFloat, Self, Generic, TypeAlias, TypeVar, runtime_checkable
 from pydantic import Field
 from pydantic.generics import GenericModel
 from algobattle.util import CustomEncodable, EncodableModel, Role, inherit_docs
-
-logger = logging.getLogger("algobattle.problem")
 
 
 _Problem: TypeAlias = Any
@@ -141,7 +138,6 @@ class Problem(CustomEncodable, ABC):
             sys.modules[spec.name] = problem_module
             spec.loader.exec_module(problem_module)
         except Exception as e:
-            logger.critical(f"Importing the given problem failed with the following exception: {e}")
             raise ValueError from e
 
         try:
@@ -162,7 +158,6 @@ class Problem(CustomEncodable, ABC):
             return problem_cls
 
         except Exception as e:
-            logger.critical(f"Importing the given problem failed with the following exception: {e}")
             raise ValueError from e
         finally:
             sys.modules.pop("_problem")

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -5,8 +5,10 @@ from inspect import isclass
 import sys
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Protocol, SupportsFloat, Self, Generic, TypeAlias, TypeVar, runtime_checkable
+
 from pydantic import Field
 from pydantic.generics import GenericModel
+
 from algobattle.util import CustomEncodable, EncodableModel, Role, inherit_docs
 
 
@@ -197,10 +199,10 @@ class ProblemModel(EncodableModel, Problem, ABC):
         """Generates the default json schema specifying the I/O for this problem."""
         return cls.schema_json(indent=4)
 
-    class Config:
+    class Config(EncodableModel.Config):
         """Pydantic config object to hide these fields in the json if someone redeclared them incorrectly."""
 
-        fields = {
+        fields: dict[str, Any] = {
             "filename": {"exclude": True},
             "name": {"exclude": True},
             "min_size": {"exclude": True},
@@ -220,10 +222,10 @@ class SolutionModel(EncodableModel, Problem.Solution, ABC):
         """Generates the default json schema specifying the I/O for this solution."""
         return cls.schema_json(indent=4)
 
-    class Config:
+    class Config(EncodableModel.Config):
         """Pydantic config object to hide these fields in the json if someone redeclared them incorrectly."""
 
-        fields = {"filename": {"exclude": True}}
+        fields: dict[str, Any] = {"filename": {"exclude": True}}
 
 
 class DirectedGraph(ProblemModel):

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -3,13 +3,10 @@ from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
 from typing import Iterable, Iterator, Self
-import logging
 
 from algobattle.docker_util import DockerConfig, DockerError, ArchivedImage, Generator, Solver
 from algobattle.problem import Problem
 from algobattle.util import TempDir
-
-logger = logging.getLogger("algobattle.team")
 
 
 _team_names: set[str] = set()
@@ -159,7 +156,6 @@ class TeamHandler:
                         team = team.archive(folder)
                         archives.append(team)
                     except Exception:
-                        logger.warning(f"Building generators and solvers for team {info.name} failed, they will be excluded!")
                         excluded.append(info)
 
                 return cls([team.restore() for team in archives], excluded)
@@ -170,7 +166,6 @@ class TeamHandler:
                     team = info.build(problem, config, auto_cleanup=safe_build)
                     teams.append(team)
                 except (ValueError, DockerError):
-                    logger.warning(f"Building generators and solvers for team {info.name} failed, they will be excluded!")
                     excluded.append(info)
             return cls(teams, excluded)
 

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -5,7 +5,9 @@ from datetime import datetime
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from traceback import format_exception
 from typing import Any, ClassVar, Iterable, Literal, Mapping, TypeVar, Self
+
 from pydantic import BaseConfig, BaseModel
 
 
@@ -15,6 +17,11 @@ Role = Literal["generator", "solver"]
 T = TypeVar("T")
 
 
+def str_with_traceback(exception: Exception) -> str:
+    """Returns the full exception info with a stacktrace."""
+    return "\n".join(format_exception(exception))
+
+
 class BaseModel(BaseModel):
     """Base class for all pydantic models."""
 
@@ -22,9 +29,8 @@ class BaseModel(BaseModel):
         """Base config for all pydandic configs."""
 
         json_encoders = {
-            Exception: str,
+            Exception: str_with_traceback,
         }
-
 
 
 def inherit_docs(obj: T) -> T:

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 from traceback import format_exception
 from typing import Any, ClassVar, Iterable, Literal, Mapping, TypeVar, Self
 
-from pydantic import BaseConfig, BaseModel
+from pydantic import BaseConfig, BaseModel, Extra
 
 
 Role = Literal["generator", "solver"]
@@ -27,6 +27,9 @@ class BaseModel(BaseModel):
 
     class Config(BaseConfig):
         """Base config for all pydandic configs."""
+
+        extra = Extra.forbid
+        underscore_attrs_are_private = False
 
 
 def inherit_docs(obj: T) -> T:

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 import json
-import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, Iterable, Literal, Mapping, TypeVar, Self
@@ -11,8 +10,6 @@ from pydantic import BaseModel
 
 
 Role = Literal["generator", "solver"]
-
-logger = logging.getLogger("algobattle.util")
 
 
 T = TypeVar("T")
@@ -93,8 +90,8 @@ def encode(data: Mapping[str, Encodable], target_dir: Path, size: int, team: Rol
             elif isinstance(obj, dict):
                 with open(target_dir / name, "w+") as f:
                     json.dump(obj, f)
-        except Exception as e:
-            logger.critical(f"Failed to encode {obj} from into files at {target_dir / name}!\nException: {e}")
+        except Exception:
+            pass
 
 
 def decode(data_spec: Mapping[str, type[Encodable]], source_dir: Path, size: int, team: Role) -> dict[str, Encodable | None]:
@@ -120,8 +117,7 @@ def decode(data_spec: Mapping[str, type[Encodable]], source_dir: Path, size: int
             elif issubclass(cls, dict):
                 with open(source_dir / name, "r") as f:
                     out[name] = json.load(f)
-        except Exception as e:
-            logger.critical(f"Failed to decode {cls} object from data at {source_dir / name}!\nException: {e}")
+        except Exception:
             out[name] = None
     return out
 

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -28,10 +28,6 @@ class BaseModel(BaseModel):
     class Config(BaseConfig):
         """Base config for all pydandic configs."""
 
-        json_encoders = {
-            Exception: str_with_traceback,
-        }
-
 
 def inherit_docs(obj: T) -> T:
     """Decorator to mark a method as inheriting its docstring.

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -6,13 +6,25 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, Iterable, Literal, Mapping, TypeVar, Self
-from pydantic import BaseModel
+from pydantic import BaseConfig, BaseModel
 
 
 Role = Literal["generator", "solver"]
 
 
 T = TypeVar("T")
+
+
+class BaseModel(BaseModel):
+    """Base class for all pydantic models."""
+
+    class Config(BaseConfig):
+        """Base config for all pydandic configs."""
+
+        json_encoders = {
+            Exception: str,
+        }
+
 
 
 def inherit_docs(obj: T) -> T:

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -10,7 +10,6 @@ from algobattle.docker_util import (
     EncodingError,
     ExecutionError,
     Generator,
-    GeneratorResult,
     Image,
     RunParameters,
     Solver,

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,7 +1,6 @@
 """Tests for all docker functions."""
 from typing import cast
 from unittest import IsolatedAsyncioTestCase, main as run_tests
-import logging
 import random
 from pathlib import Path
 
@@ -22,8 +21,6 @@ from algobattle.docker_util import (
 from algobattle.util import TempDir
 from . import testsproblem
 from .testsproblem.problem import Tests as TestProblem
-
-logging.disable(logging.CRITICAL)
 
 
 class ImageTests(IsolatedAsyncioTestCase):

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -103,64 +103,63 @@ class ProgramTests(IsolatedAsyncioTestCase):
         """The generator times out."""
         with Generator.build(*self.dockerfile("generator_timeout"), TestProblem, self.params_short) as gen:
             res = await gen.run(5)
-            self.assertIsInstance(res.result, ExecutionTimeout)
+            self.assertIsInstance(res.info.error, ExecutionTimeout)
 
     async def test_gen_exec_err(self):
         """The generator doesn't execute properly."""
         with Generator.build(*self.dockerfile("generator_execution_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
-            self.assertIsInstance(res.result, ExecutionError)
+            self.assertIsInstance(res.info.error, ExecutionError)
 
     async def test_gen_syn_err(self):
         """The generator outputs a syntactically incorrect solution."""
         with Generator.build(*self.dockerfile("generator_syntax_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
-            self.assertIsInstance(res.result, EncodingError)
+            self.assertIsInstance(res.info.error, EncodingError)
 
     async def test_gen_sem_err(self):
         """The generator outputs a semantically incorrect solution."""
         with Generator.build(*self.dockerfile("generator_semantics_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
-            self.assertIsInstance(res.result, EncodingError)
+            self.assertIsInstance(res.info.error, EncodingError)
 
     async def test_gen_succ(self):
         """The generator returns the fixed instance."""
         with Generator.build(*self.dockerfile("generator"), TestProblem, self.params) as gen:
             res = await gen.run(5)
             correct = TestProblem(semantics=True)
-            assert isinstance(res.result, GeneratorResult._Data)
-            self.assertEqual(res.result.problem, correct)
+            self.assertEqual(res.instance, correct)
 
     async def test_sol_timeout(self):
         """The solver times out."""
         with Solver.build(*self.dockerfile("solver_timeout"), TestProblem, self.params_short) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsInstance(res.result, ExecutionTimeout)
+            self.assertIsInstance(res.info.error, ExecutionTimeout)
 
     async def test_sol_exec_err(self):
         """The solver doesn't execute properly."""
         with Solver.build(*self.dockerfile("solver_execution_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsInstance(res.result, ExecutionError)
+            self.assertIsInstance(res.info.error, ExecutionError)
 
     async def test_sol_syn_err(self):
         """The solver outputs a syntactically incorrect solution."""
         with Solver.build(*self.dockerfile("solver_syntax_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsInstance(res.result, EncodingError)
+            self.assertIsInstance(res.info.error, EncodingError)
 
     async def test_sol_sem_err(self):
         """The solver outputs a semantically incorrect solution."""
         with Solver.build(*self.dockerfile("solver_semantics_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsInstance(res.result, EncodingError)
+            self.assertIsInstance(res.info.error, EncodingError)
 
     async def test_sol_succ(self):
         """The solver outputs a solution with a low quality."""
         with Solver.build(*self.dockerfile("solver"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             correct = TestProblem.Solution(semantics=True, quality=True)
-            self.assertEqual(res.result, correct)
+            self.assertEqual(res.solution, correct)
 
 
 if __name__ == "__main__":

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from algobattle.docker_util import (
     ExecutionTimeout,
     BuildError,
-    EncodingError,
     ExecutionError,
     Generator,
     Image,
@@ -102,25 +101,29 @@ class ProgramTests(IsolatedAsyncioTestCase):
         """The generator times out."""
         with Generator.build(*self.dockerfile("generator_timeout"), TestProblem, self.params_short) as gen:
             res = await gen.run(5)
-            self.assertIsInstance(res.info.error, ExecutionTimeout)
+            assert res.info.error is not None
+            self.assertEqual(res.info.error.type, "ExecutionTimeout")
 
     async def test_gen_exec_err(self):
         """The generator doesn't execute properly."""
         with Generator.build(*self.dockerfile("generator_execution_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
-            self.assertIsInstance(res.info.error, ExecutionError)
+            assert res.info.error is not None
+            self.assertEqual(res.info.error.type, "ExecutionError")
 
     async def test_gen_syn_err(self):
         """The generator outputs a syntactically incorrect solution."""
         with Generator.build(*self.dockerfile("generator_syntax_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
-            self.assertIsInstance(res.info.error, EncodingError)
+            assert res.info.error is not None
+            self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_gen_sem_err(self):
         """The generator outputs a semantically incorrect solution."""
         with Generator.build(*self.dockerfile("generator_semantics_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
-            self.assertIsInstance(res.info.error, EncodingError)
+            assert res.info.error is not None
+            self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_gen_succ(self):
         """The generator returns the fixed instance."""
@@ -133,25 +136,29 @@ class ProgramTests(IsolatedAsyncioTestCase):
         """The solver times out."""
         with Solver.build(*self.dockerfile("solver_timeout"), TestProblem, self.params_short) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsInstance(res.info.error, ExecutionTimeout)
+            assert res.info.error is not None
+            self.assertEqual(res.info.error.type, "ExecutionTimeout")
 
     async def test_sol_exec_err(self):
         """The solver doesn't execute properly."""
         with Solver.build(*self.dockerfile("solver_execution_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsInstance(res.info.error, ExecutionError)
+            assert res.info.error is not None
+            self.assertEqual(res.info.error.type, "ExecutionError")
 
     async def test_sol_syn_err(self):
         """The solver outputs a syntactically incorrect solution."""
         with Solver.build(*self.dockerfile("solver_syntax_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsInstance(res.info.error, EncodingError)
+            assert res.info.error is not None
+            self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_sol_sem_err(self):
         """The solver outputs a semantically incorrect solution."""
         with Solver.build(*self.dockerfile("solver_semantics_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsInstance(res.info.error, EncodingError)
+            assert res.info.error is not None
+            self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_sol_succ(self):
         """The solver outputs a solution with a low quality."""

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -7,7 +7,7 @@ from algobattle.cli import BattleConfig, ExecutionConfig, parse_cli_args
 from algobattle.battle import Fight, Iterated, Averaged
 from algobattle.match import MatchConfig, Match, Ui
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo
-from algobattle.docker_util import DockerConfig, GeneratorResult, ProgramError, RunParameters, get_os_type
+from algobattle.docker_util import DockerConfig, ProgramRunInfo, RunParameters, get_os_type
 from .testsproblem import Problem as TestProblem
 
 
@@ -21,7 +21,18 @@ class TestTeam(Team):
 def dummy_result(*score: float) -> list[Fight]:
     """Creates a list of dummy results for testing."""
     return [
-        Fight(s, 0, GeneratorResult(ProgramError(""), 0, 0, RunParameters()), None)
+        Fight(
+            score=s,
+            size=0,
+            generator=ProgramRunInfo(
+                params=RunParameters(),
+                runtime=0,
+            ),
+            solver=ProgramRunInfo(
+                params=RunParameters(),
+                runtime=0,
+            ),
+        )
         for s in score
     ]
 
@@ -36,6 +47,10 @@ class Matchtests(TestCase):
         cls.team1 = TestTeam("1")
         cls.matchup0 = Matchup(cls.team0, cls.team1)
         cls.matchup1 = Matchup(cls.team1, cls.team0)
+        cls.team_dict = {
+            "active_teams": [cls.team0.name, cls.team1.name],
+            "excluded_teams": [],
+        }
         cls.teams = TeamHandler((cls.team0, cls.team1))
 
     def test_all_battle_pairs_two_teams(self):
@@ -49,88 +64,88 @@ class Matchtests(TestCase):
 
     def test_calculate_points_zero_rounds(self):
         """All teams get 0 points if no rounds have been fought."""
-        match = Match(MatchConfig(), Iterated.Config(), TestProblem, self.teams)
-        self.assertEqual(match.calculate_points(), {self.team0.name: 0, self.team1.name: 0})
+        match = Match(**self.team_dict)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 0, self.team1.name: 0})
 
     def test_calculate_points_iterated_no_successful_round(self):
         """Two teams should get an equal amount of points if nobody solved anything."""
-        match = Match(MatchConfig(), Iterated.Config(), TestProblem, self.teams)
-        battle = Iterated(Ui.BattleObserver(Ui(), self.matchup0))
+        match = Match(**self.team_dict)
+        battle = Iterated()
         battle.results = [0]
-        match.results[self.matchup0] = battle
-        match.results[self.matchup1] = battle
-        self.assertEqual(match.calculate_points(), {self.team0.name: 50, self.team1.name: 50})
+        match.insert_battle(battle, self.matchup0)
+        match.insert_battle(battle, self.matchup1)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 50, self.team1.name: 50})
 
     def test_calculate_points_iterated_draw(self):
         """Two teams should get an equal amount of points if both solved a problem equally well."""
-        match = Match(MatchConfig(), Iterated.Config(), TestProblem, self.teams)
-        battle = Iterated(Ui.BattleObserver(Ui(), self.matchup0))
+        match = Match(**self.team_dict)
+        battle = Iterated()
         battle.results = [20]
-        match.results[self.matchup0] = battle
-        match.results[self.matchup1] = battle
-        self.assertEqual(match.calculate_points(), {self.team0.name: 50, self.team1.name: 50})
+        match.insert_battle(battle, self.matchup0)
+        match.insert_battle(battle, self.matchup1)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 50, self.team1.name: 50})
 
     def test_calculate_points_iterated_domination(self):
         """One team should get all points if it solved anything and the other team nothing."""
-        match = Match(MatchConfig(), Iterated.Config(), TestProblem, self.teams)
-        battle = Iterated(Ui.BattleObserver(Ui(), self.matchup0))
+        match = Match(**self.team_dict)
+        battle = Iterated()
         battle.results = [10]
-        battle2 = Iterated(Ui.BattleObserver(Ui(), self.matchup0))
+        battle2 = Iterated()
         battle2.results = [0]
-        match.results[self.matchup0] = battle
-        match.results[self.matchup1] = battle2
-        self.assertEqual(match.calculate_points(), {self.team0.name: 0, self.team1.name: 100})
+        match.insert_battle(battle, self.matchup0)
+        match.insert_battle(battle2, self.matchup1)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 0, self.team1.name: 100})
 
     def test_calculate_points_iterated_one_team_better(self):
         """One team should get more points than the other if it performed better."""
-        match = Match(MatchConfig(), Iterated.Config(), TestProblem, self.teams)
-        battle = Iterated(Ui.BattleObserver(Ui(), self.matchup0))
+        match = Match(**self.team_dict)
+        battle = Iterated()
         battle.results = [10]
-        battle2 = Iterated(Ui.BattleObserver(Ui(), self.matchup0))
+        battle2 = Iterated()
         battle2.results = [20]
-        match.results[self.matchup0] = battle
-        match.results[self.matchup1] = battle2
-        self.assertEqual(match.calculate_points(), {self.team0.name: 66.7, self.team1.name: 33.3})
+        match.insert_battle(battle, self.matchup0)
+        match.insert_battle(battle2, self.matchup1)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 66.7, self.team1.name: 33.3})
 
     def test_calculate_points_averaged_no_successful_round(self):
         """Two teams should get an equal amount of points if nobody solved anything."""
-        match = Match(MatchConfig(battle_type=Averaged), Averaged.Config(), TestProblem, self.teams)
-        battle = Averaged(Ui.BattleObserver(Ui(), self.matchup0))
+        match = Match(**self.team_dict)
+        battle = Averaged()
         battle.fight_results = dummy_result(0, 0, 0)
-        match.results[self.matchup0] = battle
-        match.results[self.matchup1] = battle
-        self.assertEqual(match.calculate_points(), {self.team0.name: 50, self.team1.name: 50})
+        match.insert_battle(battle, self.matchup0)
+        match.insert_battle(battle, self.matchup1)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 50, self.team1.name: 50})
 
     def test_calculate_points_averaged_draw(self):
         """Two teams should get an equal amount of points if both solved a problem equally well."""
-        match = Match(MatchConfig(battle_type=Averaged), Averaged.Config(), TestProblem, self.teams)
-        battle = Averaged(Ui.BattleObserver(Ui(), self.matchup0))
+        match = Match(**self.team_dict)
+        battle = Averaged()
         battle.fight_results = dummy_result(.5, .5, .5)
-        match.results[self.matchup0] = battle
-        match.results[self.matchup1] = battle
-        self.assertEqual(match.calculate_points(), {self.team0.name: 50, self.team1.name: 50})
+        match.insert_battle(battle, self.matchup0)
+        match.insert_battle(battle, self.matchup1)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 50, self.team1.name: 50})
 
     def test_calculate_points_averaged_domination(self):
         """One team should get all points if it solved anything and the other team nothing."""
-        match = Match(MatchConfig(battle_type=Averaged), Averaged.Config(), TestProblem, self.teams)
-        battle = Averaged(Ui.BattleObserver(Ui(), self.matchup0))
+        match = Match(**self.team_dict)
+        battle = Averaged()
         battle.fight_results = dummy_result(0, 0, 0)
-        battle2 = Averaged(Ui.BattleObserver(Ui(), self.matchup0))
+        battle2 = Averaged()
         battle2.fight_results = dummy_result(1, 1, 1)
-        match.results[self.matchup0] = battle
-        match.results[self.matchup1] = battle2
-        self.assertEqual(match.calculate_points(), {self.team0.name: 100, self.team1.name: 0})
+        match.insert_battle(battle, self.matchup0)
+        match.insert_battle(battle2, self.matchup1)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 100, self.team1.name: 0})
 
     def test_calculate_points_averaged_one_team_better(self):
         """One team should get more points than the other if it performed better."""
-        match = Match(MatchConfig(battle_type=Averaged), Averaged.Config(), TestProblem, self.teams)
-        battle = Averaged(Ui.BattleObserver(Ui(), self.matchup0))
+        match = Match(**self.team_dict)
+        battle = Averaged()
         battle.fight_results = dummy_result(.6, .6, .6)
-        battle2 = Averaged(Ui.BattleObserver(Ui(), self.matchup0))
+        battle2 = Averaged()
         battle2.fight_results = dummy_result(.4, .4, .4)
-        match.results[self.matchup0] = battle
-        match.results[self.matchup1] = battle2
-        self.assertEqual(match.calculate_points(), {self.team0.name: 40, self.team1.name: 60})
+        match.insert_battle(battle, self.matchup0)
+        match.insert_battle(battle2, self.matchup1)
+        self.assertEqual(match.calculate_points(100), {self.team0.name: 40, self.team1.name: 60})
 
     # TODO: Add tests for remaining functions
 
@@ -145,8 +160,8 @@ class Execution(IsolatedAsyncioTestCase):
         cls.config = MatchConfig()
         run_params = RunParameters(timeout=2)
         cls.docker_config = DockerConfig(generator=run_params, solver=run_params)
-        cls.iter_config = Iterated.Config(iteration_cap=10, rounds=2)
-        cls.avg_config = Averaged.Config(instance_size=5, iterations=3)
+        cls.iter_config = Iterated.BattleConfig(iteration_cap=10, rounds=2)
+        cls.avg_config = Averaged.BattleConfig(instance_size=5, iterations=3)
         cls.generator = problem_path / "generator"
         cls.solver = problem_path / "solver"
         if get_os_type() == "windows":
@@ -189,7 +204,7 @@ class Parsing(TestCase):
         problem, cfg = parse_cli_args([str(self.problem_path)])
         self.assertEqual(problem, self.problem_path)
         self.assertEqual(cfg, BattleConfig(teams=self.teams))
-        self.assertEqual(cfg.battle_config, Iterated.Config())
+        self.assertEqual(cfg.battle_config, Iterated.BattleConfig())
 
     def test_empty_cfg(self):
         problem, cfg = parse_cli_args(
@@ -197,7 +212,7 @@ class Parsing(TestCase):
         )
         self.assertEqual(problem, self.problem_path)
         self.assertEqual(cfg, BattleConfig(teams=self.teams))
-        self.assertEqual(cfg.battle_config, Iterated.Config())
+        self.assertEqual(cfg.battle_config, Iterated.BattleConfig())
 
     def test_cfg(self):
         problem, cfg = parse_cli_args(
@@ -213,7 +228,7 @@ class Parsing(TestCase):
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
             battle={
-                "averaged": Averaged.Config(iterations=1),
+                "averaged": Averaged.BattleConfig(iterations=1),
             }
         ))
 
@@ -238,7 +253,7 @@ class Parsing(TestCase):
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
             battle={
-                "averaged": Averaged.Config(iterations=1),
+                "averaged": Averaged.BattleConfig(iterations=1),
             },
         ))
 
@@ -263,7 +278,7 @@ class Parsing(TestCase):
             execution=ExecutionConfig(safe_build=True),
             docker=DockerConfig(generator=RunParameters(space=10)),
             battle={
-                "averaged": Averaged.Config(iterations=1),
+                "averaged": Averaged.BattleConfig(iterations=1),
             },
         ))
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -3,7 +3,7 @@
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from pathlib import Path
 
-from algobattle.cli import Config, ExecutionConfig, parse_cli_args
+from algobattle.cli import BattleConfig, ExecutionConfig, parse_cli_args
 from algobattle.battle import Fight, Iterated, Averaged
 from algobattle.match import MatchConfig, Match, Ui
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo
@@ -188,7 +188,7 @@ class Parsing(TestCase):
     def test_no_cfg_default(self):
         problem, cfg = parse_cli_args([str(self.problem_path)])
         self.assertEqual(problem, self.problem_path)
-        self.assertEqual(cfg, Config(teams=self.teams))
+        self.assertEqual(cfg, BattleConfig(teams=self.teams))
         self.assertEqual(cfg.battle_config, Iterated.Config())
 
     def test_empty_cfg(self):
@@ -196,7 +196,7 @@ class Parsing(TestCase):
             [str(self.problem_path), "--config", str(self.configs_path / "empty.toml")]
         )
         self.assertEqual(problem, self.problem_path)
-        self.assertEqual(cfg, Config(teams=self.teams))
+        self.assertEqual(cfg, BattleConfig(teams=self.teams))
         self.assertEqual(cfg.battle_config, Iterated.Config())
 
     def test_cfg(self):
@@ -204,7 +204,7 @@ class Parsing(TestCase):
             [str(self.problem_path), "--config", str(self.configs_path / "test.toml")]
         )
         self.assertEqual(problem, self.problem_path)
-        self.assertEqual(cfg, Config(
+        self.assertEqual(cfg, BattleConfig(
             match=MatchConfig(
                 points=10,
                 battle_type=Averaged,
@@ -229,7 +229,7 @@ class Parsing(TestCase):
             ]
         )
         self.assertEqual(problem, self.problem_path)
-        self.assertEqual(cfg, Config(
+        self.assertEqual(cfg, BattleConfig(
             match=MatchConfig(
                 points=10,
                 battle_type=Averaged,
@@ -254,7 +254,7 @@ class Parsing(TestCase):
             ]
         )
         self.assertEqual(problem, self.problem_path)
-        self.assertEqual(cfg, Config(
+        self.assertEqual(cfg, BattleConfig(
             match=MatchConfig(
                 points=20,
                 battle_type=Iterated,
@@ -277,7 +277,7 @@ class Parsing(TestCase):
 
     def test_cfg_team(self):
         _, cfg = parse_cli_args([str(self.problem_path), f"--config={self.configs_path / 'teams.toml'}"])
-        self.assertEqual(cfg, Config(
+        self.assertEqual(cfg, BattleConfig(
             teams=[TeamInfo("team 1", Path(), Path()), TeamInfo("team 2", Path(), Path())]
         ))
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,17 +1,14 @@
 """Tests for the Match class."""
 # pyright: reportMissingSuperCall=false
 from unittest import IsolatedAsyncioTestCase, TestCase, main
-import logging
 from pathlib import Path
 
-from algobattle.cli import Config, ExecutionConfig, parse_cli_args, setup_logging
+from algobattle.cli import Config, ExecutionConfig, parse_cli_args
 from algobattle.battle import Fight, Iterated, Averaged
 from algobattle.match import MatchConfig, Match, Ui
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo
 from algobattle.docker_util import DockerConfig, GeneratorResult, ProgramError, RunParameters, get_os_type
 from .testsproblem import Problem as TestProblem
-
-logging.disable(logging.CRITICAL)
 
 
 class TestTeam(Team):
@@ -143,8 +140,6 @@ class Execution(IsolatedAsyncioTestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        logging.disable(logging.NOTSET)  # reenable logging
-        setup_logging(Path.home() / ".algobattle_logs", verbose_logging=True, silent=False)
         problem_path = Path(__file__).parent / "testsproblem"
         cls.problem = TestProblem
         cls.config = MatchConfig()
@@ -157,11 +152,6 @@ class Execution(IsolatedAsyncioTestCase):
         if get_os_type() == "windows":
             cls.generator /= "Dockerfile_windows"
             cls.solver /= "Dockerfile_windows"
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        logging.disable(logging.CRITICAL)
-        return super().tearDownClass()
 
     async def test_basic(self):
         team = TeamInfo("team0", self.generator, self.solver)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,5 @@
 """Tests for all util functions."""
 import unittest
-import logging
 import random
 from pathlib import Path
 
@@ -8,9 +7,6 @@ from algobattle.match import MatchConfig
 from algobattle.problem import Problem
 from algobattle.battle import Battle, Iterated, Averaged
 from . import testsproblem
-
-logging.disable(logging.CRITICAL)
-
 
 class Utiltests(unittest.TestCase):
     """Tests for the util functions."""

--- a/tests/testsproblem/problem.py
+++ b/tests/testsproblem/problem.py
@@ -1,14 +1,7 @@
 """Problem class built for tests."""
-import logging
 from typing import ClassVar, SupportsFloat
 
 from algobattle.problem import ProblemModel, SolutionModel
-
-logger = logging.getLogger('algobattle.problems.testsproblem')
-
-
-
-
 
 
 class Tests(ProblemModel):


### PR DESCRIPTION
This moves a bunch of code around to make it possible to serialize the match objects we generate, and removes the then unnecessary logging messages. This makes it so we can easily display the match in the web interface, and gives a much more detailed and programatically parseable view into what happened to users who are testing their code.

The cli interface is also changed marginally since we don't have a logging path anymore and we don't dump the resulting match object by default. Maybe we should default to doing that, but that would mean choosing some path on the user's device to write a bunch of json data into, which seems iffy. Since we now have a nicer cli output users shouldn't really need the resulting json file generally.