### PR TITLE
Simplify cli config

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -180,12 +180,12 @@ class Battle(BaseModel):
         for entrypoint in entry_points(group="algobattle.battle"):
             if entrypoint.name not in Battle._battle_types:
                 battle: type[Battle] = entrypoint.load()
-                Battle._battle_types[battle.name().lower()] = battle
+                Battle._battle_types[battle.name()] = battle
         return Battle._battle_types
 
     def __init_subclass__(cls) -> None:
         if cls.name() not in Battle._battle_types:
-            Battle._battle_types[cls.name().lower()] = cls
+            Battle._battle_types[cls.name()] = cls
         return super().__init_subclass__()
 
     @abstractmethod

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -173,32 +173,6 @@ class Battle(BaseModel):
     class BattleConfig(BaseModel):
         """Object containing the config variables the battle types use."""
 
-        @classmethod
-        def as_argparse_args(cls) -> list[tuple[str, dict[str, Any]]]:
-            """Transforms the config specification into argparse arguments.
-
-            Constructs a list of argument names and `**kwargs` that can be passed
-            to `ArgumentParser.add_argument()`.
-            """
-            arguments: list[tuple[str, dict[str, Any]]] = []
-            resolved_annotations = get_type_hints(cls)
-            for name, model_field in cls.__fields__.items():
-                kwargs = model_field.field_info.extra
-                kwargs["help"] = kwargs.get("help", "") + f" Default: {model_field.default}"
-                if resolved_annotations[name] == bool and "action" not in kwargs and "const" not in kwargs:
-                    kwargs["action"] = "store_const"
-                    kwargs["const"] = not model_field.default
-                elif get_origin(resolved_annotations[name]) == Literal and "choices" not in kwargs:
-                    kwargs["choices"] = resolved_annotations[name].__args__
-
-                arguments.append((model_field.name, kwargs))
-            return arguments
-
-        class Config(BaseModel.Config):
-            """Pydandtic config."""
-
-            validate_assignment = True
-
     class UiData(BaseModel):
         """Object containing custom diplay data."""
 

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -12,8 +12,6 @@ from typing import (
     Protocol,
     TypeAlias,
     TypeVar,
-    get_origin,
-    get_type_hints,
     overload,
 )
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -44,7 +44,7 @@ class BattleConfig(BaseModel):
     @property
     def battle_config(self) -> Battle.BattleConfig:
         """The config object for the used battle type."""
-        return self.battle[self.match.battle_type.name().lower()]
+        return self.battle[self.match.battle_type]
 
     @validator("battle", pre=True)
     def val_battle_configs(cls, vals):

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -1,5 +1,5 @@
 """Main battle script. Executes all possible types of battles, see battle --help for all options."""
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 from contextlib import ExitStack
 import curses
 from dataclasses import dataclass, field
@@ -7,7 +7,7 @@ from functools import partial
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Mapping, ParamSpec, Self, TypeVar
+from typing import Any, Callable, Mapping, ParamSpec, Self, TypeVar
 import tomllib
 from importlib.metadata import version as pkg_version
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -145,12 +145,6 @@ def parse_cli_args(args: list[str]) -> tuple[Path, BattleConfig]:
     )
     parser.add_argument("--solver_cpus", type=int, help="Number of cpu cores used for solver container execution.")
 
-    # battle types have their configs automatically added to the CLI args
-    for battle_name, battle in Battle.all().items():
-        group = parser.add_argument_group(battle_name)
-        for name, kwargs in battle.BattleConfig.as_argparse_args():
-            group.add_argument(f"--{battle_name.lower()}_{name}", **kwargs)
-
     parsed = parser.parse_args(args)
     problem: Path = parsed.problem
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -14,7 +14,7 @@ from prettytable import DOUBLE_BORDER, PrettyTable
 from anyio import create_task_group, run, sleep
 
 from algobattle.battle import Battle, Fight, FightUiData
-from algobattle.docker_util import GeneratorResult, Image, ProgramRunInfo, SolverResult
+from algobattle.docker_util import GeneratorResult, ProgramRunInfo, SolverResult
 from algobattle.match import MatchConfig, Match, Ui
 from algobattle.problem import Problem
 from algobattle.team import Matchup, TeamInfo
@@ -59,10 +59,6 @@ def parse_cli_args(args: list[str]) -> tuple[CliOptions, MatchConfig]:
             raise ValueError(f"Invalid config file, terminating execution.\n{e}")
     else:
         config = MatchConfig()
-    if config.docker.advanced_run_params is not None:
-        Image.run_kwargs = config.docker.advanced_run_params.to_docker_args()
-    if config.docker.advanced_build_params is not None:
-        Image.run_kwargs = config.docker.advanced_build_params.to_docker_args()
 
     if not config.teams:
         config.teams.append(

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -50,6 +50,7 @@ class DockerConfig(BaseModel):
     """Grouped config options that are relevant to the interaction with docker."""
 
     build_timeout: float | None = None
+    safe_build: bool = False
     generator: RunParameters = RunParameters()
     solver: RunParameters = RunParameters()
     advanced_run_params: "AdvancedRunArgs | None" = None

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -13,7 +13,7 @@ from anyio.to_thread import current_default_thread_limiter
 from anyio.abc import TaskStatus
 
 from algobattle.battle import Battle, FightHandler, FightUiProxy, BattleUiProxy
-from algobattle.docker_util import DockerConfig, ProgramRunInfo, ProgramUiProxy
+from algobattle.docker_util import DockerConfig, Image, ProgramRunInfo, ProgramUiProxy
 from algobattle.team import Matchup, Team, TeamHandler, TeamInfo
 from algobattle.problem import Problem
 from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
@@ -107,6 +107,10 @@ class Match(BaseModel):
         """Executes a match with the specified parameters."""
         if ui is None:
             ui = Ui()
+        if config.docker.advanced_run_params is not None:
+            Image.run_kwargs = config.docker.advanced_run_params.to_docker_args()
+        if config.docker.advanced_build_params is not None:
+            Image.run_kwargs = config.docker.advanced_build_params.to_docker_args()
         with TeamHandler.build(config.teams, problem, config.docker) as teams:
             result = cls(
                 active_teams=[t.name for t in teams.active],

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -140,12 +140,10 @@ class TeamHandler:
         super().__init__()
 
     @classmethod
-    def build(
-        cls, infos: list[TeamInfo], problem: type[Problem], config: DockerConfig, safe_build: bool = False
-    ) -> Self:
+    def build(cls, infos: list[TeamInfo], problem: type[Problem], config: DockerConfig) -> Self:
         """Builds the specified team objects."""
         excluded: list[TeamInfo] = []
-        if safe_build:
+        if config.safe_build:
             with TempDir() as folder:
                 archives: list[_ArchivedTeam] = []
                 for info in infos:

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -36,7 +36,7 @@ class TeamInfo:
         generator = Generator.build(self.generator, self.name, problem, config.generator, config.build_timeout)
         try:
             solver = Solver.build(self.solver, self.name, problem, config.solver, config.build_timeout)
-        except:
+        except Exception:
             generator.remove()
             raise
         return Team(name, generator, solver)

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,6 +1,3 @@
-[execution]
-safe_build = true
-
 [match]
 points = 10
 battle_type = "averaged"

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,9 +1,8 @@
-[match]
 points = 10
-battle_type = "averaged"
+battle_type = "Averaged"
 
 [docker.generator]
 space = 10
 
-[battle.averaged]
+[battle.Averaged]
 iterations = 1

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -161,9 +161,9 @@ class Execution(IsolatedAsyncioTestCase):
         cls.config = MatchConfig(
             docker=DockerConfig(generator=run_params, solver=run_params),
             battle={
-            "Iterated": Iterated.BattleConfig(iteration_cap=10, rounds=2),
-            "Averaged": Averaged.BattleConfig(instance_size=5, iterations=3),
-            }
+                "Iterated": Iterated.BattleConfig(iteration_cap=10, rounds=2),
+                "Averaged": Averaged.BattleConfig(instance_size=5, iterations=3),
+            },
         )
         cls.generator = problem_path / "generator"
         cls.solver = problem_path / "solver"

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -179,7 +179,7 @@ class Execution(IsolatedAsyncioTestCase):
     async def test_averaged(self):
         team = TeamInfo("team0", self.generator, self.solver)
         with TeamHandler.build([team], self.problem, self.docker_config, safe_build=True) as teams:
-            config = MatchConfig(battle_type=Averaged)
+            config = MatchConfig(battle_type="Averaged")
             await Match.run(config, self.avg_config, TestProblem, teams, Ui())
 
 
@@ -219,7 +219,7 @@ class Parsing(TestCase):
             BattleConfig(
                 match=MatchConfig(
                     points=10,
-                    battle_type=Averaged,
+                    battle_type="Averaged",
                 ),
                 teams=self.teams,
                 docker=DockerConfig(generator=RunParameters(space=10)),
@@ -246,7 +246,7 @@ class Parsing(TestCase):
             BattleConfig(
                 match=MatchConfig(
                     points=10,
-                    battle_type=Averaged,
+                    battle_type="Averaged",
                 ),
                 teams=self.teams,
                 docker=DockerConfig(generator=RunParameters(space=10)),
@@ -273,7 +273,7 @@ class Parsing(TestCase):
             BattleConfig(
                 match=MatchConfig(
                     points=20,
-                    battle_type=Iterated,
+                    battle_type="Iterated",
                 ),
                 teams=self.teams,
                 docker=DockerConfig(generator=RunParameters(space=10)),

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -3,7 +3,7 @@
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from pathlib import Path
 
-from algobattle.cli import BattleConfig, ExecutionConfig, parse_cli_args
+from algobattle.cli import BattleConfig, parse_cli_args
 from algobattle.battle import Fight, Iterated, Averaged
 from algobattle.match import MatchConfig, Match, Ui
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo
@@ -222,7 +222,6 @@ class Parsing(TestCase):
                     battle_type=Averaged,
                 ),
                 teams=self.teams,
-                execution=ExecutionConfig(safe_build=True),
                 docker=DockerConfig(generator=RunParameters(space=10)),
                 battle={
                     "averaged": Averaged.BattleConfig(iterations=1),
@@ -250,7 +249,6 @@ class Parsing(TestCase):
                     battle_type=Averaged,
                 ),
                 teams=self.teams,
-                execution=ExecutionConfig(safe_build=True),
                 docker=DockerConfig(generator=RunParameters(space=10)),
                 battle={
                     "averaged": Averaged.BattleConfig(iterations=1),
@@ -278,7 +276,6 @@ class Parsing(TestCase):
                     battle_type=Iterated,
                 ),
                 teams=self.teams,
-                execution=ExecutionConfig(safe_build=True),
                 docker=DockerConfig(generator=RunParameters(space=10)),
                 battle={
                     "averaged": Averaged.BattleConfig(iterations=1),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -32,8 +32,8 @@ class Utiltests(unittest.TestCase):
 
     def test_default_battle_types(self):
         """Initializing an existing battle type works as expected."""
-        self.assertEqual(Battle.all()["iterated"], Iterated)
-        self.assertEqual(Battle.all()["averaged"], Averaged)
+        self.assertEqual(Battle.all()["Iterated"], Iterated)
+        self.assertEqual(Battle.all()["Averaged"], Averaged)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This simplifies the config parsing step by removing the option to set the match specific options from the cli. Now only the options that are relevant to the actual cli invocation are set from it, i.e. the path to the problem and config files, whether the ui is displayed, and if and where to dump the resulting match object. All other config settings are set in the config file.