### PR TITLE
Simplify folder structure

### DIFF
--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -391,7 +391,7 @@ class Program(ABC):
         return cls(image, config, problem_class)
 
     @abstractmethod
-    def _setup_folders(self, input: Path, output: Path, size: int, instance: Problem | None) -> None:
+    def _encode_input(self, input: Path, output: Path, size: int, instance: Problem | None) -> None:
         """Sets up the i/o folders as required for the specific type of program."""
         raise NotImplementedError
 
@@ -424,7 +424,7 @@ class Program(ABC):
 
         with TempDir() as input, TempDir() as output:
             try:
-                self._setup_folders(input, output, size, input_instance)
+                self._encode_input(input, output, size, input_instance)
             except AlgobattleBaseException as e:
                 return result_class(ProgramRunInfo(params=run_params, runtime=0, error=ExceptionInfo.from_exception(e)))
             with open(input / "info.json", "w+") as f:
@@ -520,7 +520,7 @@ class Generator(Program):
 
     role: ClassVar[Role] = "generator"
 
-    def _setup_folders(self, input: Path, output: Path, size: int, instance: Problem | None) -> None:
+    def _encode_input(self, input: Path, output: Path, size: int, instance: Problem | None) -> None:
         assert instance is None
         with open(input / "size", "w+") as f:
             f.write(str(size))
@@ -602,7 +602,7 @@ class Solver(Program):
 
     role: ClassVar[Role] = "solver"
 
-    def _setup_folders(self, input: Path, output: Path, size: int, instance: Problem | None) -> None:
+    def _encode_input(self, input: Path, output: Path, size: int, instance: Problem | None) -> None:
         assert instance is not None
         instance.encode(input / "instance", size, self.role)
 

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -438,7 +438,6 @@ class Program(ABC):
                     f,
                 )
             if battle_input is not None:
-                (input / "battle_data").mkdir()
                 try:
                     battle_input.encode(input / "battle_data", size, self.role)
                 except Exception as e:
@@ -449,8 +448,6 @@ class Program(ABC):
                             error=ExceptionInfo(type="EncodingError", message=f"Battle data couldn't be encoded:\n{e}"),
                         )
                     )
-            if battle_output is not None:
-                (output / "battle_data").mkdir()
 
             try:
                 runtime = await self.image.run(input, output, timeout=timeout, memory=space, cpus=cpus, ui=ui)
@@ -527,9 +524,6 @@ class Generator(Program):
         assert instance is None
         with open(input / "size", "w+") as f:
             f.write(str(size))
-        (output / "instance").mkdir()
-        if self.problem_class.with_solution:
-            (output / "solution").mkdir()
 
     def _parse_output(self, output: Path, size: int, instance: Problem | None) -> _GenResData:
         assert instance is None
@@ -610,9 +604,7 @@ class Solver(Program):
 
     def _setup_folders(self, input: Path, output: Path, size: int, instance: Problem | None) -> None:
         assert instance is not None
-        (input / "instance").mkdir()
         instance.encode(input / "instance", size, self.role)
-        (output / "solution").mkdir()
 
     def _parse_output(self, output: Path, size: int, instance: Problem | None) -> Problem.Solution:
         assert instance is not None

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -522,7 +522,7 @@ class Generator(Program):
 
     def _encode_input(self, input: Path, output: Path, size: int, instance: Problem | None) -> None:
         assert instance is None
-        with open(input / "size", "w+") as f:
+        with open(input / "size.txt", "w+") as f:
             f.write(str(size))
 
     def _parse_output(self, output: Path, size: int, instance: Problem | None) -> _GenResData:

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -189,7 +189,6 @@ class Problem(Encodable, ABC):
 class ProblemModel(EncodableModel, Problem, ABC):
     """A Problem that can easily be parsed to/from a json file."""
 
-    filename: ClassVar[str] = "instance.json"
     export: ClassVar[bool] = False
 
     class Config(EncodableModel.Config):
@@ -207,8 +206,6 @@ class ProblemModel(EncodableModel, Problem, ABC):
 
 class SolutionModel(EncodableModel, Problem.Solution, ABC):
     """A solution that can easily be parsed to/from a json file."""
-
-    filename: ClassVar[str] = "solution.json"
 
     class Config(EncodableModel.Config):
         """Pydantic config object to hide these fields in the json if someone redeclared them incorrectly."""

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 from traceback import format_exception
 from typing import Any, Iterable, Literal, TypeVar, Self
 
-from pydantic import BaseConfig, BaseModel, Extra, ValidationError as PydanticValidationError
+from pydantic import BaseConfig, BaseModel as PydandticBaseModel, Extra, ValidationError as PydanticValidationError
 
 
 Role = Literal["generator", "solver"]
@@ -23,7 +23,7 @@ def str_with_traceback(exception: Exception) -> str:
     return "\n".join(format_exception(exception))
 
 
-class BaseModel(BaseModel):
+class BaseModel(PydandticBaseModel):
     """Base class for all pydantic models."""
 
     class Config(BaseConfig):

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -130,23 +130,20 @@ class Encodable(ABC):
 class EncodableModel(BaseModel, Encodable, ABC):
     """Problem data that can easily be encoded into and decoded from json files."""
 
-    filename: ClassVar[str]
-
     @classmethod
-    def decode(cls, source_dir: Path, size: int, team: Role) -> Self:
-        """Uses pydantic to create a python object from a json file found at `source_dir / cls.filename`."""
+    def decode(cls, source: Path, size: int, team: Role) -> Self:
+        """Uses pydantic to create a python object from a `.json` file."""
         try:
-            return cls.parse_file(source_dir / cls.filename)
+            return cls.parse_file(source.with_suffix(".json"))
         except PydanticValidationError as e:
             raise EncodingError("Json data does not fit the schema.", detail=str(e))
         except Exception as e:
             raise EncodingError("Unknown error while decoding the data.", detail=str(e))
 
-    @inherit_docs
-    def encode(self, target_dir: Path, size: int, team: Role) -> None:
-        """Uses pydantic to create a json representation of the object at `target_dir / cls.filename`."""
+    def encode(self, target: Path, size: int, team: Role) -> None:
+        """Uses pydantic to create a json representation of the object at the targeted file."""
         try:
-            with open(target_dir / self.filename, "w") as f:
+            with open(target.with_suffix(".json"), "w") as f:
                 f.write(self.json(exclude=self._excludes(team)))
         except Exception as e:
             raise EncodingError("Unkown error while encoding the data.", detail=str(e))

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -80,12 +80,13 @@ class Encodable(ABC):
 
     @classmethod
     @abstractmethod
-    def decode(cls, source_dir: Path, size: int, team: Role) -> Self:
-        """Decodes the data found in the given folder into a python object.
+    def decode(cls, source: Path, size: int, team: Role) -> Self:
+        """Decodes the data found at the given path into a python object.
 
         Args:
-            source_dir: Path to a directory containing the data that can be used to construct an instance of this class.
-            size: The size of the data to be decoded.
+            source: Path to data that can be used to construct an instance of this class. May either point to a folder
+                or a single file. The expected type of path should be consistent with the result of :meth:`.encode`.
+            size: The size of the fight for which this data is being decoded.
             team: Role of the team that output the data.
 
         Raises:
@@ -97,11 +98,13 @@ class Encodable(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def encode(self, target_dir: Path, size: int, team: Role) -> None:
-        """Encodes the object into a folder that can be passed to a program.
+    def encode(self, target: Path, size: int, team: Role) -> None:
+        """Encodes the object onto the file system so that it can be passed to a program.
 
         Args:
-            target_dir: Path to a directory that will be passed as the input of a program.
+            target: Path to the location where the program expects the encoded data. :meth:`.encode` may either create
+                a single file at the target location, or an entire folder. If creating a single file, it may append a
+                file type ending to the path. It should not affect any other files or directories.
             size: The size of the data to be encoded.
             team: Role of the team that receives the data.
 
@@ -114,7 +117,7 @@ class Encodable(ABC):
     def io_schema(cls) -> str | None:
         """Generates a schema specifying the I/O for this data.
 
-        The schema should specify the structure of the data in the input and output folders.
+        The schema should specify the structure of the data in the input and output files or folders.
         In particular, the specification should match precisely what :meth`.decode` accepts, and the output of
         :meth:`.encode` should comply with it.
 

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from traceback import format_exception
-from typing import Any, ClassVar, Iterable, Literal, TypeVar, Self
+from typing import Any, Iterable, Literal, TypeVar, Self
 
 from pydantic import BaseConfig, BaseModel, Extra, ValidationError as PydanticValidationError
 

--- a/tests/testsproblem/generator/Dockerfile
+++ b/tests/testsproblem/generator/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static instance and certificate
 COPY instance.json /instance.json
-ENTRYPOINT mv /instance.json /output/instance/instance.json
+ENTRYPOINT mv /instance.json /output/instance.json

--- a/tests/testsproblem/generator_semantics_error/Dockerfile
+++ b/tests/testsproblem/generator_semantics_error/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static string encoding an instance with an artificially wrong certificate.
 COPY instance.json /instance.json
-ENTRYPOINT mv /instance.json /output/instance/instance.json
+ENTRYPOINT mv /instance.json /output/instance.json

--- a/tests/testsproblem/generator_syntax_error/Dockerfile
+++ b/tests/testsproblem/generator_syntax_error/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, artificially malformed solution.
 COPY instance.json /instance.json
-ENTRYPOINT mv /instance.json /output/instance/instance.json
+ENTRYPOINT mv /instance.json /output/instance.json

--- a/tests/testsproblem/solver/Dockerfile
+++ b/tests/testsproblem/solver/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static solution.
 COPY solution.json /solution.json
-ENTRYPOINT mv /solution.json /output/solution/solution.json
+ENTRYPOINT mv /solution.json /output/solution.json

--- a/tests/testsproblem/solver_semantics_error/Dockerfile
+++ b/tests/testsproblem/solver_semantics_error/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, artificially wrong solution.
 COPY solution.json /solution.json
-ENTRYPOINT mv /solution.json /output/solution/solution.json
+ENTRYPOINT mv /solution.json /output/solution.json

--- a/tests/testsproblem/solver_syntax_error/Dockerfile
+++ b/tests/testsproblem/solver_syntax_error/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static, semantically wrong solution.
 COPY solution.json /solution.json
-ENTRYPOINT mv /solution.json /output/solution/solution.json
+ENTRYPOINT mv /solution.json /output/solution.json


### PR DESCRIPTION
This PR just simplifies the folder structure inside the docker containers. Previously I had made the requirement that all problem instances, solutions, and the addition data battles can pass are each encoded into their own folder. But many such classes, in particular the ones we create with pydantic models, only need a single file.  
In addition, I also added a `.txt` file extension to the size input the generator receives to make its encoding more clear.

This now relaxes that condition, each object is encoded into its own path. It is up to the particular class to decide whether it needs a whole folder or a single file is sufficient. This removes an unnecessary level of nesting in many cases.

For example, for many problems the student solver code now interacts with `input/instance.json` and `output/solution.json` instead of `input/instance/instance.json` and `output/solution/solution.json`.