### PR TITLE
pin pydantic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "windows-curses; os_name == 'nt'",
 
     "prettytable",
-    "pydantic",
+    "pydantic < 2",
     "anyio",
 ]
 


### PR DESCRIPTION
This just pins the pydantic version to one that is backwards compatible with our code.