### PR TITLE
Improve build step UI

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -22,7 +22,7 @@ from algobattle.docker_util import (
     ProgramUiProxy,
     Solver,
 )
-from algobattle.util import Encodable, Role, TimerInfo, inherit_docs, BaseModel
+from algobattle.util import Encodable, Role, inherit_docs, BaseModel
 
 
 _BattleConfig: TypeAlias = Any

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -166,15 +166,6 @@ class FightHandler:
         return self._saved(Fight(score=score, size=size, generator=gen_result.info, solver=sol_result.info))
 
 
-@dataclass
-class FightUiData:
-    """Holds display data about the currently executing fight."""
-
-    size: int
-    generator: TimerInfo | float | ProgramRunInfo | None = None
-    solver: TimerInfo | float | ProgramRunInfo | None = None
-
-
 # We need this to be here to prevent an import cycle between match.py and battle.py
 class BattleUiProxy(Protocol):
     """Provides an interface for :cls:`Battle`s to update the Ui."""

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -92,11 +92,6 @@ def main():
     """Entrypoint of `algobattle` CLI."""
     try:
         exec_config, config = parse_cli_args(sys.argv[1:])
-
-    except KeyboardInterrupt:
-        raise SystemExit("Received keyboard interrupt, terminating execution.")
-
-    try:
         problem = Problem.import_from_path(exec_config.problem_path)
         with ExitStack() as stack:
             if exec_config.silent:
@@ -120,7 +115,7 @@ def main():
                     f.write(result.json())
 
     except KeyboardInterrupt:
-        print("Received keyboard interrupt, terminating execution.")
+        raise SystemExit("Received keyboard interrupt, terminating execution.")
 
 
 P = ParamSpec("P")

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -172,6 +172,7 @@ class CliUi(Ui):
         """Notifies the Ui that a specific battle has been completed."""
         self.battle_data.pop(matchup, None)
         self.fight_data.pop(matchup, None)
+        super().battle_completed(matchup)
 
     def update_battle_data(self, matchup: Matchup, data: Battle.UiData) -> None:
         """Passes new custom battle data to the Ui."""

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -207,7 +207,8 @@ class CliUi(Ui):
         terminal_height, _ = self.stdscr.getmaxyx()
         out: list[str] = []
         out.append(f"Algobattle version {pkg_version(__package__)}")
-        out += self.display_match(self.match)
+        if self.match is not None:
+            out += self.display_match(self.match)
         for matchup in self.active_battles:
             out += [
                 "",
@@ -299,6 +300,8 @@ class CliUi(Ui):
 
     def display_battle(self, matchup: Matchup) -> list[str]:
         """Formats the battle data into a string that can be printed to the terminal."""
+        if self.match is None:
+            return []
         battle = self.match.results[matchup.generator.name][matchup.solver.name]
         fights = battle.fight_results[-3:] if len(battle.fight_results) >= 3 else battle.fight_results
         sections: list[list[str]] = []

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -236,7 +236,7 @@ class CliUi(Ui):
             runtime = (datetime.now() - status.start).total_seconds()
             status_str = f"Building {status.role} of team {status.team}: {runtime:3.1f}s"
             if status.timeout is not None:
-                out += f" / {status.timeout:3.1f}s"
+                status_str += f" / {status.timeout:3.1f}s"
             out.append(status_str)
 
         if self.match is not None:

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -176,15 +176,15 @@ class CliUi(Ui):
         curses.echo()
         curses.endwin()
 
-    def start(self, team: str, role: Role, timeout: float | None) -> None:
+    def start_build(self, team: str, role: Role, timeout: float | None) -> None:
         """Informs the ui that a new program is being built."""
         self.build_status = _BuildInfo(team, role, timeout, datetime.now())
 
-    def finish(self) -> None:
+    def finish_build(self) -> None:
         """Informs the ui that the current build has been finished."""
         self.build_status = None
 
-    def initialize(self) -> None:
+    def initialize_programs(self) -> None:
         """Informs the ui that the programs are being initialized."""
         self.build_status = "Initializing programs..."
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -16,7 +16,7 @@ from prettytable import DOUBLE_BORDER, PrettyTable
 from anyio import create_task_group, run, sleep
 from anyio.abc import TaskGroup
 
-from algobattle.battle import Battle, Fight, FightUiData
+from algobattle.battle import Battle, Fight
 from algobattle.docker_util import GeneratorResult, ProgramRunInfo, SolverResult
 from algobattle.match import MatchConfig, Match, Ui
 from algobattle.problem import Problem
@@ -135,6 +135,13 @@ class _BuildInfo:
 
 
 @dataclass
+class _FightUiData:
+    size: int
+    generator: TimerInfo | float | ProgramRunInfo | None = None
+    solver: TimerInfo | float | ProgramRunInfo | None = None
+
+
+@dataclass
 class CliUi(Ui):
     """A :cls:`Ui` displaying the data to the cli.
 
@@ -142,7 +149,7 @@ class CliUi(Ui):
     """
 
     battle_data: dict[Matchup, Battle.UiData] = field(default_factory=dict, init=False)
-    fight_data: dict[Matchup, FightUiData] = field(default_factory=dict, init=False)
+    fight_data: dict[Matchup, _FightUiData] = field(default_factory=dict, init=False)
     task_group: TaskGroup | None = field(default=None, init=False)
     build_status: _BuildInfo | str | None = field(default=None, init=False)
 
@@ -194,7 +201,7 @@ class CliUi(Ui):
 
     def start_fight(self, matchup: Matchup, size: int) -> None:
         """Informs the Ui of a newly started fight."""
-        self.fight_data[matchup] = FightUiData(size, None, None)
+        self.fight_data[matchup] = _FightUiData(size, None, None)
 
     def update_curr_fight(
         self,

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -187,6 +187,12 @@ class CliUi(Ui):
     def initialize_programs(self) -> None:
         """Informs the ui that the programs are being initialized."""
         self.build_status = "Initializing programs..."
+        self.update()
+
+    def finish_init_programs(self) -> None:
+        """Informs the ui that all programs have been initialized."""
+        self.build_status = None
+        self.update()
 
     @check_for_terminal
     def battle_completed(self, matchup: Matchup) -> None:

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -133,7 +133,21 @@ class Image:
     A full description can be found at the docker api reference."""
 
     @classmethod
-    def build(
+    def _build_image(cls, path: str, tag: str, timeout: float | None, dockerfile: str | None) -> DockerImage:
+        image, _logs = cast(
+            tuple[DockerImage, Iterator[Any]],
+            client().images.build(
+                path=str(path),
+                tag=tag,
+                timeout=timeout,
+                dockerfile=dockerfile,
+                **cls.build_kwargs,
+            ),
+        )
+        return image
+
+    @classmethod
+    async def build(
         cls,
         path: Path,
         image_name: str,
@@ -161,16 +175,7 @@ class Image:
                 old_image = cast(DockerImage, client().images.get(image_name))
             except ImageNotFound:
                 old_image = None
-            image, _logs = cast(
-                tuple[DockerImage, Iterator[Any]],
-                client().images.build(
-                    path=str(path),
-                    tag=image_name,
-                    timeout=timeout,
-                    dockerfile=dockerfile,
-                    **cls.build_kwargs,
-                ),
-            )
+            image = await run_sync(cls._build_image, str(path), image_name, timeout, dockerfile)
             if old_image is not None:
                 old_image.reload()
                 if len(old_image.tags) == 0:
@@ -370,7 +375,7 @@ class Program(ABC):
     role: ClassVar[Role]
 
     @classmethod
-    def build(
+    async def build(
         cls,
         image: Path | Image | ArchivedImage,
         team_name: str,
@@ -380,7 +385,7 @@ class Program(ABC):
     ) -> Self:
         """Creates a program by building the specified docker image."""
         if isinstance(image, Path):
-            image = Image.build(
+            image = await Image.build(
                 path=image,
                 image_name=f"{team_name}_{cls.role}",
                 timeout=timeout,

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -270,6 +270,10 @@ class Ui:
         """Informs the ui that the programs are being initialized."""
         return
 
+    def finish_init_programs(self) -> None:
+        """Informs the ui that all programs have been initialized."""
+        return
+
     def start_battle(self, matchup: Matchup) -> None:
         """Notifies the Ui that a battle has been started."""
         self.active_battles.append(matchup)

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -79,7 +79,7 @@ class Match(BaseModel):
     ) -> None:
         async with limiter:
             ui.start_battle(matchup)
-            battle_ui = ui.get_battle_observer(matchup)
+            battle_ui = ui.BattleObserver(ui, matchup)
             handler = FightHandler(matchup.generator.generator, matchup.solver.solver, battle, battle_ui.fight_ui)
             try:
                 await battle.run_battle(
@@ -118,7 +118,7 @@ class Match(BaseModel):
             Image.run_kwargs = config.docker.advanced_run_params.to_docker_args()
         if config.docker.advanced_build_params is not None:
             Image.run_kwargs = config.docker.advanced_build_params.to_docker_args()
-        with TeamHandler.build(config.teams, problem, config.docker) as teams:
+        with TeamHandler.build(config.teams, problem, config.docker, ui) as teams:
             result = cls(
                 active_teams=[t.name for t in teams.active],
                 excluded_teams=[t.name for t in teams.excluded],
@@ -240,9 +240,17 @@ class Ui:
     match: Match | None = field(default=None, init=False)
     active_battles: list[Matchup] = field(default_factory=list, init=False)
 
-    def get_battle_observer(self, matchup: Matchup) -> "BattleObserver":
-        """Creates an observer for a specifc battle."""
-        return self.BattleObserver(self, matchup)
+    def start(self, team: str, role: Role, timeout: float | None) -> None:
+        """Informs the ui that a new program is being built."""
+        return
+
+    def finish(self) -> None:
+        """Informs the ui that the current build has been finished."""
+        return
+
+    def initialize(self) -> None:
+        """Informs the ui that the programs are being initialized."""
+        return
 
     def start_battle(self, matchup: Matchup) -> None:
         """Notifies the Ui that a battle has been started."""

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -258,15 +258,15 @@ class Ui:
     match: Match | None = field(default=None, init=False)
     active_battles: list[Matchup] = field(default_factory=list, init=False)
 
-    def start(self, team: str, role: Role, timeout: float | None) -> None:
+    def start_build(self, team: str, role: Role, timeout: float | None) -> None:
         """Informs the ui that a new program is being built."""
         return
 
-    def finish(self) -> None:
+    def finish_build(self) -> None:
         """Informs the ui that the current build has been finished."""
         return
 
-    def initialize(self) -> None:
+    def initialize_programs(self) -> None:
         """Informs the ui that the programs are being initialized."""
         return
 

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -118,7 +118,7 @@ class Match(BaseModel):
             Image.run_kwargs = config.docker.advanced_run_params.to_docker_args()
         if config.docker.advanced_build_params is not None:
             Image.run_kwargs = config.docker.advanced_build_params.to_docker_args()
-        with TeamHandler.build(config.teams, problem, config.docker, ui) as teams:
+        with await TeamHandler.build(config.teams, problem, config.docker, ui) as teams:
             result = cls(
                 active_teams=[t.name for t in teams.active],
                 excluded_teams=[t.name for t in teams.excluded],

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -134,7 +134,7 @@ class Match(BaseModel):
         with await TeamHandler.build(config.teams, problem, config.docker, ui) as teams:
             result = cls(
                 active_teams=[t.name for t in teams.active],
-                excluded_teams=[t.name for t in teams.excluded],
+                excluded_teams=[t for t in teams.excluded],
             )
             ui.match = result
             battle_cls = Battle.all()[config.battle_type]

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -241,7 +241,7 @@ class Ui:
     by just subclassing :cls:`Ui` and implementing its methods.
     """
 
-    match: Match = field(init=False)
+    match: Match | None = field(default=None, init=False)
     active_battles: list[Matchup] = field(default_factory=list, init=False)
 
     def get_battle_observer(self, matchup: Matchup) -> "BattleObserver":

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -37,7 +37,7 @@ class TeamInfo:
     generator: Path
     solver: Path
 
-    def build(self, problem: type[Problem], config: DockerConfig, ui: BuildUiProxy) -> "Team":
+    async def build(self, problem: type[Problem], config: DockerConfig, ui: BuildUiProxy) -> "Team":
         """Builds the specified docker files into images and return the corresponding team.
 
         Raises:
@@ -48,11 +48,11 @@ class TeamInfo:
         if name in _team_names:
             raise ValueError
         ui.start(name, "generator", config.build_timeout)
-        generator = Generator.build(self.generator, self.name, problem, config.generator, config.build_timeout)
+        generator = await Generator.build(self.generator, self.name, problem, config.generator, config.build_timeout)
         ui.finish()
         try:
             ui.start(name, "solver", config.build_timeout)
-            solver = Solver.build(self.solver, self.name, problem, config.solver, config.build_timeout)
+            solver = await Solver.build(self.solver, self.name, problem, config.solver, config.build_timeout)
             ui.finish()
         except Exception:
             generator.remove()
@@ -149,7 +149,7 @@ class TeamHandler:
     excluded: list[TeamInfo]
 
     @classmethod
-    def build(
+    async def build(
         cls, infos: list[TeamInfo], problem: type[Problem], config: DockerConfig, ui: BuildUiProxy,
     ) -> Self:
         """Builds the programs of every team.
@@ -174,7 +174,7 @@ class TeamHandler:
                 archives: list[_ArchivedTeam] = []
                 for info in infos:
                     try:
-                        team = info.build(problem, config, ui)
+                        team = await info.build(problem, config, ui)
                         team = team.archive(folder)
                         archives.append(team)
                     except Exception:
@@ -185,7 +185,7 @@ class TeamHandler:
             teams: list[Team] = []
             for info in infos:
                 try:
-                    team = info.build(problem, config, ui)
+                    team = await info.build(problem, config, ui)
                     teams.append(team)
                 except (ValueError, DockerError):
                     excluded.append(info)

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -28,6 +28,10 @@ class BuildUiProxy(Protocol):
     def initialize_programs(self) -> None:
         """Informs the ui that the programs are being initialized."""
 
+    @abstractmethod
+    def finish_init_programs(self) -> None:
+        """Informs the ui that all programs have been initialized."""
+
 
 @dataclass
 class TeamInfo:

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -17,15 +17,15 @@ class BuildUiProxy(Protocol):
     """Provides and interface for the build process to update the ui."""
 
     @abstractmethod
-    def start(self, team: str, role: Role, timeout: float | None) -> None:
+    def start_build(self, team: str, role: Role, timeout: float | None) -> None:
         """Informs the ui that a new program is being built."""
 
     @abstractmethod
-    def finish(self) -> None:
+    def finish_build(self) -> None:
         """Informs the ui that the current build has been finished."""
 
     @abstractmethod
-    def initialize(self) -> None:
+    def initialize_programs(self) -> None:
         """Informs the ui that the programs are being initialized."""
 
 
@@ -47,13 +47,13 @@ class TeamInfo:
         name = self.name.replace(" ", "_").lower()  # Lower case needed for docker tag created from name
         if name in _team_names:
             raise ValueError
-        ui.start(name, "generator", config.build_timeout)
+        ui.start_build(name, "generator", config.build_timeout)
         generator = await Generator.build(self.generator, self.name, problem, config.generator, config.build_timeout)
-        ui.finish()
+        ui.finish_build()
         try:
-            ui.start(name, "solver", config.build_timeout)
+            ui.start_build(name, "solver", config.build_timeout)
             solver = await Solver.build(self.solver, self.name, problem, config.solver, config.build_timeout)
-            ui.finish()
+            ui.finish_build()
         except Exception:
             generator.remove()
             raise
@@ -179,7 +179,7 @@ class TeamHandler:
                         archives.append(team)
                     except Exception as e:
                         handler.excluded[info.name] = ExceptionInfo.from_exception(e)
-                ui.initialize()
+                ui.initialize_programs()
                 handler.active = [team.restore() for team in archives]
         else:
             for info in infos:

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -1,15 +1,32 @@
 """Module containing helper classes related to teams."""
+from abc import abstractmethod
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
-from typing import Iterator, Self
+from typing import Iterator, Protocol, Self
 
 from algobattle.docker_util import DockerConfig, DockerError, ArchivedImage, Generator, Solver
 from algobattle.problem import Problem
-from algobattle.util import TempDir
+from algobattle.util import Role, TempDir
 
 
 _team_names: set[str] = set()
+
+
+class BuildUiProxy(Protocol):
+    """Provides and interface for the build process to update the ui."""
+
+    @abstractmethod
+    def start(self, team: str, role: Role, timeout: float | None) -> None:
+        """Informs the ui that a new program is being built."""
+
+    @abstractmethod
+    def finish(self) -> None:
+        """Informs the ui that the current build has been finished."""
+
+    @abstractmethod
+    def initialize(self) -> None:
+        """Informs the ui that the programs are being initialized."""
 
 
 @dataclass
@@ -20,7 +37,7 @@ class TeamInfo:
     generator: Path
     solver: Path
 
-    def build(self, problem: type[Problem], config: DockerConfig) -> "Team":
+    def build(self, problem: type[Problem], config: DockerConfig, ui: BuildUiProxy) -> "Team":
         """Builds the specified docker files into images and return the corresponding team.
 
         Raises:
@@ -30,9 +47,13 @@ class TeamInfo:
         name = self.name.replace(" ", "_").lower()  # Lower case needed for docker tag created from name
         if name in _team_names:
             raise ValueError
+        ui.start(name, "generator", config.build_timeout)
         generator = Generator.build(self.generator, self.name, problem, config.generator, config.build_timeout)
+        ui.finish()
         try:
+            ui.start(name, "solver", config.build_timeout)
             solver = Solver.build(self.solver, self.name, problem, config.solver, config.build_timeout)
+            ui.finish()
         except Exception:
             generator.remove()
             raise
@@ -128,7 +149,9 @@ class TeamHandler:
     excluded: list[TeamInfo]
 
     @classmethod
-    def build(cls, infos: list[TeamInfo], problem: type[Problem], config: DockerConfig) -> Self:
+    def build(
+        cls, infos: list[TeamInfo], problem: type[Problem], config: DockerConfig, ui: BuildUiProxy,
+    ) -> Self:
         """Builds the programs of every team.
 
         Attempts to build the programs of every team. If any build fails, that team will be excluded and all its
@@ -151,18 +174,18 @@ class TeamHandler:
                 archives: list[_ArchivedTeam] = []
                 for info in infos:
                     try:
-                        team = info.build(problem, config)
+                        team = info.build(problem, config, ui)
                         team = team.archive(folder)
                         archives.append(team)
                     except Exception:
                         excluded.append(info)
-
+                ui.initialize()
                 return cls([team.restore() for team in archives], excluded)
         else:
             teams: list[Team] = []
             for info in infos:
                 try:
-                    team = info.build(problem, config)
+                    team = info.build(problem, config, ui)
                     teams.append(team)
                 except (ValueError, DockerError):
                     excluded.append(info)

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -239,10 +239,17 @@ class ExceptionInfo(BaseModel):
     detail: str | None = None
 
     @classmethod
-    def from_exception(cls, error: AlgobattleBaseException) -> Self:
+    def from_exception(cls, error: Exception) -> Self:
         """Constructs an instance from a raised exception."""
-        return cls(
-            type=error.__class__.__name__,
-            message=error.message,
-            detail=error.detail,
-        )
+        if isinstance(error, AlgobattleBaseException):
+            return cls(
+                type=error.__class__.__name__,
+                message=error.message,
+                detail=error.detail,
+            )
+        else:
+            return cls(
+                type=error.__class__.__name__,
+                message=str(error),
+                detail=str_with_traceback(error),
+            )

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -63,7 +63,10 @@ class ImageTests(IsolatedAsyncioTestCase):
 
     async def test_run_error(self):
         """Raises an error if the container doesn't run successfully."""
-        with self.assertRaises(ExecutionError), await Image.build(*self.dockerfile("generator_execution_error")) as image:
+        with (
+            self.assertRaises(ExecutionError),
+            await Image.build(*self.dockerfile("generator_execution_error")) as image,
+        ):
             await image.run(timeout=10.0)
 
     async def test_archive(self):

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -32,43 +32,43 @@ class ImageTests(IsolatedAsyncioTestCase):
     def dockerfile(cls, name: str) -> tuple[Path, str]:
         return cls.problem_path / name, name
 
-    def test_build_timeout(self):
+    async def test_build_timeout(self):
         """Raises an error if building a container runs into a timeout."""
-        with self.assertRaises(BuildError), Image.build(*self.dockerfile("build_timeout"), timeout=0.5):
+        with self.assertRaises(BuildError), await Image.build(*self.dockerfile("build_timeout"), timeout=0.5):
             pass
 
-    def test_build_failed(self):
+    async def test_build_failed(self):
         """Raises an error if building a docker container fails for any reason other than a timeout."""
-        with self.assertRaises(BuildError), Image.build(*self.dockerfile("build_error")):
+        with self.assertRaises(BuildError), await Image.build(*self.dockerfile("build_error")):
             pass
 
-    def test_build_successful(self):
+    async def test_build_successful(self):
         """Runs successfully if a docker container builds successfully."""
-        with Image.build(*self.dockerfile("generator")):
+        with await Image.build(*self.dockerfile("generator")):
             pass
 
-    def test_build_nonexistant_path(self):
+    async def test_build_nonexistant_path(self):
         """Raises an error if the path to the container does not exist in the file system."""
         with self.assertRaises(RuntimeError):
             nonexistent_file = None
             while nonexistent_file is None or nonexistent_file.exists():
                 nonexistent_file = Path(str(random.randint(0, 2**80)))
-            with Image.build(nonexistent_file, "foo_bar"):
+            with await Image.build(nonexistent_file, "foo_bar"):
                 pass
 
     async def test_run_timeout(self):
         """`Image.run()` raises an error when the container times out."""
-        with Image.build(*self.dockerfile("generator_timeout")) as image, self.assertRaises(ExecutionTimeout):
+        with await Image.build(*self.dockerfile("generator_timeout")) as image, self.assertRaises(ExecutionTimeout):
             await image.run(timeout=1.0)
 
     async def test_run_error(self):
         """Raises an error if the container doesn't run successfully."""
-        with self.assertRaises(ExecutionError), Image.build(*self.dockerfile("generator_execution_error")) as image:
+        with self.assertRaises(ExecutionError), await Image.build(*self.dockerfile("generator_execution_error")) as image:
             await image.run(timeout=10.0)
 
-    def test_archive(self):
+    async def test_archive(self):
         """Raises an error if the image can't be archived and restored properly."""
-        with Image.build(*self.dockerfile("generator")) as image, TempDir() as folder:
+        with await Image.build(*self.dockerfile("generator")) as image, TempDir() as folder:
             original_tag = cast(DockerImage, client().images.get(image.id)).tags[0]
             archived = image.archive(folder)
             assert (folder / "generator-archive.tar").is_file()
@@ -95,70 +95,70 @@ class ProgramTests(IsolatedAsyncioTestCase):
 
     async def test_gen_timeout(self):
         """The generator times out."""
-        with Generator.build(*self.dockerfile("generator_timeout"), TestProblem, self.params_short) as gen:
+        with await Generator.build(*self.dockerfile("generator_timeout"), TestProblem, self.params_short) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionTimeout")
 
     async def test_gen_exec_err(self):
         """The generator doesn't execute properly."""
-        with Generator.build(*self.dockerfile("generator_execution_error"), TestProblem, self.params) as gen:
+        with await Generator.build(*self.dockerfile("generator_execution_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionError")
 
     async def test_gen_syn_err(self):
         """The generator outputs a syntactically incorrect solution."""
-        with Generator.build(*self.dockerfile("generator_syntax_error"), TestProblem, self.params) as gen:
+        with await Generator.build(*self.dockerfile("generator_syntax_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_gen_sem_err(self):
         """The generator outputs a semantically incorrect solution."""
-        with Generator.build(*self.dockerfile("generator_semantics_error"), TestProblem, self.params) as gen:
+        with await Generator.build(*self.dockerfile("generator_semantics_error"), TestProblem, self.params) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ValidationError")
 
     async def test_gen_succ(self):
         """The generator returns the fixed instance."""
-        with Generator.build(*self.dockerfile("generator"), TestProblem, self.params) as gen:
+        with await Generator.build(*self.dockerfile("generator"), TestProblem, self.params) as gen:
             res = await gen.run(5)
             correct = TestProblem(semantics=True)
             self.assertEqual(res.instance, correct)
 
     async def test_sol_timeout(self):
         """The solver times out."""
-        with Solver.build(*self.dockerfile("solver_timeout"), TestProblem, self.params_short) as sol:
+        with await Solver.build(*self.dockerfile("solver_timeout"), TestProblem, self.params_short) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionTimeout")
 
     async def test_sol_exec_err(self):
         """The solver doesn't execute properly."""
-        with Solver.build(*self.dockerfile("solver_execution_error"), TestProblem, self.params) as sol:
+        with await Solver.build(*self.dockerfile("solver_execution_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionError")
 
     async def test_sol_syn_err(self):
         """The solver outputs a syntactically incorrect solution."""
-        with Solver.build(*self.dockerfile("solver_syntax_error"), TestProblem, self.params) as sol:
+        with await Solver.build(*self.dockerfile("solver_syntax_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_sol_sem_err(self):
         """The solver outputs a semantically incorrect solution."""
-        with Solver.build(*self.dockerfile("solver_semantics_error"), TestProblem, self.params) as sol:
+        with await Solver.build(*self.dockerfile("solver_semantics_error"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ValidationError")
 
     async def test_sol_succ(self):
         """The solver outputs a solution with a low quality."""
-        with Solver.build(*self.dockerfile("solver"), TestProblem, self.params) as sol:
+        with await Solver.build(*self.dockerfile("solver"), TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             correct = TestProblem.Solution(semantics=True, quality=True)
             self.assertEqual(res.solution, correct)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -51,7 +51,7 @@ class Matchtests(TestCase):
             "active_teams": [cls.team0.name, cls.team1.name],
             "excluded_teams": [],
         }
-        cls.teams = TeamHandler([cls.team0, cls.team1], [])
+        cls.teams = TeamHandler([cls.team0, cls.team1])
 
     def test_all_battle_pairs_two_teams(self):
         """Two teams both generate and solve one time each."""
@@ -59,7 +59,7 @@ class Matchtests(TestCase):
 
     def test_all_battle_pairs_single_player(self):
         """A team playing against itself is the only battle pair in single player."""
-        teams = TeamHandler([self.team0], [])
+        teams = TeamHandler([self.team0])
         self.assertEqual(teams.matchups, [Matchup(self.team0, self.team0)])
 
     def test_calculate_points_zero_rounds(self):


### PR DESCRIPTION
This PR adds a basic UI output to the build step and more detailed error info in the resulting log object should a build fail.

The cli ui currently hangs when archiving/restoring the images. I've found a much better way to prevent images from spying on each other and will open a PR with those changes next, so I'd rather not implement a nicer UI here if it's gonna get removed with the next PR anyways.