### PR TITLE
Redo the safe build option

### DIFF
--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -184,16 +184,6 @@ class CliUi(Ui):
         """Informs the ui that the current build has been finished."""
         self.build_status = None
 
-    def initialize_programs(self) -> None:
-        """Informs the ui that the programs are being initialized."""
-        self.build_status = "Initializing programs..."
-        self.update()
-
-    def finish_init_programs(self) -> None:
-        """Informs the ui that all programs have been initialized."""
-        self.build_status = None
-        self.update()
-
     @check_for_terminal
     def battle_completed(self, matchup: Matchup) -> None:
         """Notifies the Ui that a specific battle has been completed."""

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from timeit import default_timer
 from typing import Any, ClassVar, Iterator, Protocol, Self, TypedDict, cast
-from uuid import uuid1
+from uuid import uuid1, uuid4
 import json
 from dataclasses import dataclass
 
@@ -115,6 +115,7 @@ class Image:
             tuple[DockerImage, Iterator[Any]],
             client().images.build(
                 path=str(path),
+                tag=f"algobattle_{uuid4().hex[:8]}",
                 timeout=timeout,
                 dockerfile=dockerfile,
                 **cls.build_kwargs,

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from timeit import default_timer
 from typing import Any, ClassVar, Iterator, Protocol, Self, TypedDict, cast
-from uuid import uuid1, uuid4
+from uuid import uuid4
 import json
 from dataclasses import dataclass
 
@@ -195,7 +195,7 @@ class Image:
         Returns:
             The runtime of the program.
         """
-        name = f"algobattle_{uuid1().hex[:8]}"
+        name = f"algobattle_{uuid4().hex[:8]}"
         if memory is not None:
             memory = memory * 1_000_000
         cpus = cpus * 1_000_000_000
@@ -238,7 +238,7 @@ class Image:
                 try:
                     container.remove(force=True)
                 except APIError as e:
-                    raise DockerError(f"Couldn't remove {name}", detail=str(e)) from e
+                    raise DockerError(f"Couldn't remove container.", detail=str(e)) from e
 
         return elapsed_time
 

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -104,6 +104,7 @@ class Image:
         "forcerm": True,
         "quiet": True,
         "network_mode": "host",
+        "pull": True,
     }
     """Advanced docker options passed to the docker build command.
 
@@ -772,7 +773,7 @@ class AdvancedBuildArgs(BaseModel):
     nocache: bool | None = None
     rm: bool = True
     encoding: str | None = None
-    pull: bool | None = None
+    pull: bool | None = True
     forcerm: bool = True
     buildargs: dict[Any, Any] | None = None
     container_limits: _ContainerLimits | None = None

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -132,7 +132,6 @@ class Image:
 
         Args:
             path: The path to the directory containing a `Dockerfile`, or a path to such a file itself.
-            image_name: The name of the built docker image, must follow the rules set out by the docker api.
             timeout: Timeout in seconds for the build process.
 
         Raises:

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -336,7 +336,6 @@ class Program(ABC):
     async def build(
         cls,
         image: Path | Image,
-        team_name: str,
         problem_class: type[Problem],
         config: RunParameters,
         timeout: float | None = None,

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -149,11 +149,11 @@ class Image:
             image = await run_sync(cls._build_image, str(path), timeout, dockerfile)
 
         except Timeout as e:
-            raise BuildError(f"Build ran into a timeout.") from e
+            raise BuildError("Build ran into a timeout.") from e
         except DockerBuildError as e:
-            raise BuildError(f"Build did not complete successfully.", detail=e.msg) from e
+            raise BuildError("Build did not complete successfully.", detail=e.msg) from e
         except APIError as e:
-            raise BuildError(f"Docker APIError thrown while building.", detail=str(e)) from e
+            raise BuildError("Docker APIError thrown while building.", detail=str(e)) from e
 
         return cls(cast(str, image.id), path=path)
 
@@ -230,15 +230,15 @@ class Image:
                 ui.stop(elapsed_time)
 
         except ImageNotFound as e:
-            raise RuntimeError(f"Image (id: {self.id}) does not exist.") from e
+            raise RuntimeError("Image (id: {self.id}) does not exist.") from e
         except APIError as e:
-            raise DockerError(f"Docker APIError thrown while running container.", detail=str(e)) from e
+            raise DockerError("Docker APIError thrown while running container.", detail=str(e)) from e
         finally:
             if container is not None:
                 try:
                     container.remove(force=True)
                 except APIError as e:
-                    raise DockerError(f"Couldn't remove container.", detail=str(e)) from e
+                    raise DockerError("Couldn't remove container.", detail=str(e)) from e
 
         return elapsed_time
 
@@ -257,7 +257,7 @@ class Image:
         except ImageNotFound:
             pass
         except APIError as e:
-            raise DockerError(f"Docker APIError thrown while removing image.", detail=str(e)) from e
+            raise DockerError("Docker APIError thrown while removing image.", detail=str(e)) from e
 
     def _run_container(self, container: DockerContainer, timeout: float | None = None) -> float:
         container.start()

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -356,7 +356,7 @@ class Program(ABC):
         team_name: str | None = None,
     ) -> Self:
         """Creates a program by building the specified docker image.
-        
+
         Args:
             image: Path to a Dockerfile (or folder containing one) from which to build the image.
                 Or an already built image.

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from itertools import combinations
 from pathlib import Path
 import tomllib
-from typing import Mapping, Self, cast, overload
+from typing import Literal, Mapping, Self, cast, overload
 
 from pydantic import validator, Field
 from anyio import create_task_group, CapacityLimiter
@@ -24,6 +24,7 @@ class MatchConfig(BaseModel):
     battle_type: str = "Iterated"
     points: int = 100
     parallel_battles: int = 1
+    mode: Literal["tournament", "testing"] = "tournament"
     teams: list[TeamInfo] = []
     docker: DockerConfig = DockerConfig()
     battle: dict[str, Battle.BattleConfig] = {n: b.BattleConfig() for n, b in Battle.all().items()}
@@ -131,7 +132,7 @@ class Match(BaseModel):
         if config.docker.advanced_build_params is not None:
             Image.run_kwargs = config.docker.advanced_build_params.to_docker_args()
 
-        with await TeamHandler.build(config.teams, problem, config.docker, ui) as teams:
+        with await TeamHandler.build(config.teams, problem, config.mode == "tournament", config.docker, ui) as teams:
             result = cls(
                 active_teams=[t.name for t in teams.active],
                 excluded_teams=[t for t in teams.excluded],

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -266,14 +266,6 @@ class Ui:
         """Informs the ui that the current build has been finished."""
         return
 
-    def initialize_programs(self) -> None:
-        """Informs the ui that the programs are being initialized."""
-        return
-
-    def finish_init_programs(self) -> None:
-        """Informs the ui that all programs have been initialized."""
-        return
-
     def start_battle(self, matchup: Matchup) -> None:
         """Notifies the Ui that a battle has been started."""
         self.active_battles.append(matchup)

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from itertools import combinations
 from pathlib import Path
 import tomllib
-from typing import Literal, Mapping, Self, cast, overload
+from typing import Mapping, Self, cast, overload
 
 from pydantic import validator, Field
 from anyio import create_task_group, CapacityLimiter
@@ -15,7 +15,7 @@ from algobattle.battle import Battle, FightHandler, FightUiProxy, BattleUiProxy
 from algobattle.docker_util import DockerConfig, Image, ProgramRunInfo, ProgramUiProxy
 from algobattle.team import Matchup, Team, TeamHandler, TeamInfo
 from algobattle.problem import Problem
-from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
+from algobattle.util import MatchMode, Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
 
 
 class MatchConfig(BaseModel):
@@ -24,7 +24,7 @@ class MatchConfig(BaseModel):
     battle_type: str = "Iterated"
     points: int = 100
     parallel_battles: int = 1
-    mode: Literal["tournament", "testing"] = "tournament"
+    mode: MatchMode = "tournament"
     teams: list[TeamInfo] = []
     docker: DockerConfig = DockerConfig()
     battle: dict[str, Battle.BattleConfig] = {n: b.BattleConfig() for n, b in Battle.all().items()}
@@ -132,7 +132,7 @@ class Match(BaseModel):
         if config.docker.advanced_build_params is not None:
             Image.run_kwargs = config.docker.advanced_build_params.to_docker_args()
 
-        with await TeamHandler.build(config.teams, problem, config.mode == "tournament", config.docker, ui) as teams:
+        with await TeamHandler.build(config.teams, problem, config.mode, config.docker, ui) as teams:
             result = cls(
                 active_teams=[t.name for t in teams.active],
                 excluded_teams=[t for t in teams.excluded],

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -124,9 +124,7 @@ class TeamHandler:
     excluded: dict[str, ExceptionInfo] = field(default_factory=dict)
 
     @classmethod
-    async def build(
-        cls, infos: list[TeamInfo], problem: type[Problem], config: DockerConfig, ui: BuildUiProxy,
-    ) -> Self:
+    async def build(cls, infos: list[TeamInfo], problem: type[Problem], config: DockerConfig, ui: BuildUiProxy) -> Self:
         """Builds the programs of every team.
 
         Attempts to build the programs of every team. If any build fails, that team will be excluded and all its

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -52,11 +52,11 @@ class TeamInfo:
         if name in _team_names:
             raise ValueError
         ui.start_build(name, "generator", config.build_timeout)
-        generator = await Generator.build(self.generator, self.name, problem, config.generator, config.build_timeout)
+        generator = await Generator.build(self.generator, problem, config.generator, config.build_timeout)
         ui.finish_build()
         try:
             ui.start_build(name, "solver", config.build_timeout)
-            solver = await Solver.build(self.solver, self.name, problem, config.solver, config.build_timeout)
+            solver = await Solver.build(self.solver, problem, config.solver, config.build_timeout)
             ui.finish_build()
         except Exception:
             generator.remove()

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -24,14 +24,6 @@ class BuildUiProxy(Protocol):
     def finish_build(self) -> None:
         """Informs the ui that the current build has been finished."""
 
-    @abstractmethod
-    def initialize_programs(self) -> None:
-        """Informs the ui that the programs are being initialized."""
-
-    @abstractmethod
-    def finish_init_programs(self) -> None:
-        """Informs the ui that all programs have been initialized."""
-
 
 @dataclass
 class TeamInfo:

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -33,7 +33,9 @@ class TeamInfo:
     generator: Path
     solver: Path
 
-    async def build(self, problem: type[Problem], config: DockerConfig, name_programs: bool, ui: BuildUiProxy) -> "Team":
+    async def build(
+        self, problem: type[Problem], config: DockerConfig, name_programs: bool, ui: BuildUiProxy
+    ) -> "Team":
         """Builds the specified docker files into images and return the corresponding team.
 
         Args:

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -15,6 +15,8 @@ from pydantic import BaseConfig, BaseModel as PydandticBaseModel, Extra, Validat
 
 Role = Literal["generator", "solver"]
 """Indicates whether the role of a program is to generate or to solve instances."""
+MatchMode = Literal["tournament", "testing"]
+"""Indicates what type of match is being fought."""
 T = TypeVar("T")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     # we need to use a fixed version of the docker lib for windows
-    "docker @ git+https://github.com/ImogenBits/docker-py.git",
+    "docker @ git+https://github.com/ImogenBits/docker-py.git@windows_timeouts",
 
     # on windows, we need to manually install curses bindings
     "windows-curses; os_name == 'nt'",

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -77,76 +77,72 @@ class ProgramTests(IsolatedAsyncioTestCase):
         cls.params_short = RunParameters(timeout=2)
         cls.instance = TestProblem(semantics=True)
 
-    @classmethod
-    def dockerfile(cls, name: str) -> tuple[Path, str]:
-        return cls.problem_path / name, name
-
     async def test_gen_timeout(self):
         """The generator times out."""
-        with await Generator.build(*self.dockerfile("generator_timeout"), TestProblem, self.params_short) as gen:
+        with await Generator.build(self.problem_path / "generator_timeout", TestProblem, self.params_short) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionTimeout")
 
     async def test_gen_exec_err(self):
         """The generator doesn't execute properly."""
-        with await Generator.build(*self.dockerfile("generator_execution_error"), TestProblem, self.params) as gen:
+        with await Generator.build(self.problem_path / "generator_execution_error", TestProblem, self.params) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionError")
 
     async def test_gen_syn_err(self):
         """The generator outputs a syntactically incorrect solution."""
-        with await Generator.build(*self.dockerfile("generator_syntax_error"), TestProblem, self.params) as gen:
+        with await Generator.build(self.problem_path / "generator_syntax_error", TestProblem, self.params) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_gen_sem_err(self):
         """The generator outputs a semantically incorrect solution."""
-        with await Generator.build(*self.dockerfile("generator_semantics_error"), TestProblem, self.params) as gen:
+        with await Generator.build(self.problem_path / "generator_semantics_error", TestProblem, self.params) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ValidationError")
 
     async def test_gen_succ(self):
         """The generator returns the fixed instance."""
-        with await Generator.build(*self.dockerfile("generator"), TestProblem, self.params) as gen:
+        with await Generator.build(self.problem_path / "generator", TestProblem, self.params) as gen:
             res = await gen.run(5)
             correct = TestProblem(semantics=True)
             self.assertEqual(res.instance, correct)
 
     async def test_sol_timeout(self):
         """The solver times out."""
-        with await Solver.build(*self.dockerfile("solver_timeout"), TestProblem, self.params_short) as sol:
+        with await Solver.build(self.problem_path / "solver_timeout", TestProblem, self.params_short) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionTimeout")
 
     async def test_sol_exec_err(self):
         """The solver doesn't execute properly."""
-        with await Solver.build(*self.dockerfile("solver_execution_error"), TestProblem, self.params) as sol:
+        with await Solver.build(self.problem_path / "solver_execution_error", TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionError")
 
     async def test_sol_syn_err(self):
         """The solver outputs a syntactically incorrect solution."""
-        with await Solver.build(*self.dockerfile("solver_syntax_error"), TestProblem, self.params) as sol:
+        with await Solver.build(self.problem_path / "solver_syntax_error", TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_sol_sem_err(self):
         """The solver outputs a semantically incorrect solution."""
-        with await Solver.build(*self.dockerfile("solver_semantics_error"), TestProblem, self.params) as sol:
+        with await Solver.build(self.problem_path / "solver_semantics_error", TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ValidationError")
 
     async def test_sol_succ(self):
         """The solver outputs a solution with a low quality."""
-        with await Solver.build(*self.dockerfile("solver"), TestProblem, self.params) as sol:
+        with await Solver.build(self.problem_path / "solver", TestProblem, self.params) as sol:
             res = await sol.run(self.instance, 5)
             correct = TestProblem.Solution(semantics=True, quality=True)
             self.assertEqual(res.solution, correct)

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,5 +1,4 @@
 """Tests for all docker functions."""
-from typing import cast
 from unittest import IsolatedAsyncioTestCase, main as run_tests
 import random
 from pathlib import Path
@@ -12,10 +11,7 @@ from algobattle.docker_util import (
     Image,
     RunParameters,
     Solver,
-    client,
-    DockerImage,
 )
-from algobattle.util import TempDir
 from . import testsproblem
 from .testsproblem.problem import TestProblem as TestProblem
 
@@ -68,17 +64,6 @@ class ImageTests(IsolatedAsyncioTestCase):
             await Image.build(*self.dockerfile("generator_execution_error")) as image,
         ):
             await image.run(timeout=10.0)
-
-    async def test_archive(self):
-        """Raises an error if the image can't be archived and restored properly."""
-        with await Image.build(*self.dockerfile("generator")) as image, TempDir() as folder:
-            original_tag = cast(DockerImage, client().images.get(image.id)).tags[0]
-            archived = image.archive(folder)
-            assert (folder / "generator-archive.tar").is_file()
-            restored = archived.restore()
-            docker_image = cast(DockerImage, client().images.get(restored.id))
-            assert docker_image.id == image.id
-            assert docker_image.tags == [original_tag]
 
 
 class ProgramTests(IsolatedAsyncioTestCase):


### PR DESCRIPTION
I completely misunderstood how the docker daemon interacts with containers and how the build step operates. By default containers can't access the host's daemon in any way and even trying to install a functional daemon inside a container requires additional permissions.

This means that we don't need to archive images to prevent other teams from building off of them or interacting with them in some way. My understanding now is that the only way they have to actually interact with them is via `FROM <image>`, so there basically are two things we can do to prevent that:

1. Build them with the `pull` option. This will make it so that docker always tries to pull images from the docker hub even when a local version exists. As long as there are no images on docker hub with that name, the build process fails.
2. Don't give them deterministic tags (or none at all). If teams can't reference the other team's images then they can't build off of them.

The first option has the downside that a team may upload an image to the docker hub to prevent the build process from failing completely. I'm not sure how the versioning and caching of docker works well enough, so the uploaded image might not actually override the local one.  
Because of that, I've essentially combined it with the second option by building with the `pull` option and also giving the images random names. This means that in principle they could be referenced but only by guessing the correct name and also uploading an image with that name to the docker hub. The upside of this is that we're not creating a bunch of unnamed and unidentifiable images. I'm not super sure if this is worth the potential risk here, happy to drop that commit if you feel like building without names at all is better.

Since this fix doesn't affect the build times at all we can just always do this and thus don't need the `safe_build` option in the config at all.