### PR TITLE
Option for strict or lax timeouts

### DIFF
--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -70,6 +70,19 @@ def client() -> DockerClient:
     return _client_var
 
 
+def set_docker_config(config: DockerConfig) -> None:
+    """Sets up the static docker config attributes.
+    
+    Various classes in the docker_util module need statically set config options, e.g. advanced build/run arguments or
+    the strict_timeout option. This function propagates initializes all of these correctly.
+    """
+    if config.advanced_run_params is not None:
+        Image.run_kwargs = config.advanced_run_params.to_docker_args()
+    if config.advanced_build_params is not None:
+        Image.build_kwargs = config.advanced_build_params.to_docker_args()
+    Program.docker_config = config
+
+
 class ProgramUiProxy(Protocol):
     """Provides an interface for :cls:`Program`s to update the Ui."""
 
@@ -332,6 +345,7 @@ class Program(ABC):
     """The problem this program creates instances and/or solutions for."""
 
     role: ClassVar[Role]
+    docker_config: ClassVar[DockerConfig] = DockerConfig()
 
     @classmethod
     async def build(

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -73,7 +73,7 @@ def client() -> DockerClient:
 
 def set_docker_config(config: DockerConfig) -> None:
     """Sets up the static docker config attributes.
-    
+
     Various classes in the docker_util module need statically set config options, e.g. advanced build/run arguments or
     the strict_timeout option. This function propagates initializes all of these correctly.
     """
@@ -432,11 +432,7 @@ class Program(ABC):
             except ExecutionTimeout as e:
                 if self.docker_config.strict_timeouts:
                     return result_class(
-                        ProgramRunInfo(
-                            params=run_params,
-                            runtime=e.runtime,
-                            error=ExceptionInfo.from_exception(e)
-                        )
+                        ProgramRunInfo(params=run_params, runtime=e.runtime, error=ExceptionInfo.from_exception(e))
                     )
                 else:
                     runtime = e.runtime

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -12,7 +12,7 @@ from anyio import create_task_group, CapacityLimiter
 from anyio.to_thread import current_default_thread_limiter
 
 from algobattle.battle import Battle, FightHandler, FightUiProxy, BattleUiProxy
-from algobattle.docker_util import DockerConfig, Image, ProgramRunInfo, ProgramUiProxy
+from algobattle.docker_util import DockerConfig, Image, ProgramRunInfo, ProgramUiProxy, set_docker_config
 from algobattle.team import Matchup, Team, TeamHandler, TeamInfo
 from algobattle.problem import Problem
 from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
@@ -126,10 +126,7 @@ class Match(BaseModel):
         """
         if ui is None:
             ui = Ui()
-        if config.docker.advanced_run_params is not None:
-            Image.run_kwargs = config.docker.advanced_run_params.to_docker_args()
-        if config.docker.advanced_build_params is not None:
-            Image.run_kwargs = config.docker.advanced_build_params.to_docker_args()
+        set_docker_config(config.docker)
 
         with await TeamHandler.build(config.teams, problem, config.docker, ui) as teams:
             result = cls(

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -12,7 +12,7 @@ from anyio import create_task_group, CapacityLimiter
 from anyio.to_thread import current_default_thread_limiter
 
 from algobattle.battle import Battle, FightHandler, FightUiProxy, BattleUiProxy
-from algobattle.docker_util import DockerConfig, Image, ProgramRunInfo, ProgramUiProxy, set_docker_config
+from algobattle.docker_util import DockerConfig, ProgramRunInfo, ProgramUiProxy, set_docker_config
 from algobattle.team import Matchup, Team, TeamHandler, TeamInfo
 from algobattle.problem import Problem
 from algobattle.util import Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback

--- a/tests/testsproblem/generator_timeout/Dockerfile
+++ b/tests/testsproblem/generator_timeout/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static instance and certificate
 COPY instance.json /instance.json
-ENTRYPOINT mv /instance.json /output/instance.json && sleep 6000
+ENTRYPOINT mkdir /output && mv /instance.json /output/instance.json && sleep 6000

--- a/tests/testsproblem/generator_timeout/Dockerfile
+++ b/tests/testsproblem/generator_timeout/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine
 
-# causes an execution timeout.
-ENTRYPOINT sleep 6000
+# outputs a static instance and certificate
+COPY instance.json /instance.json
+ENTRYPOINT mv /instance.json /output/instance.json && sleep 6000

--- a/tests/testsproblem/generator_timeout/Dockerfile
+++ b/tests/testsproblem/generator_timeout/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # outputs a static instance and certificate
 COPY instance.json /instance.json
-ENTRYPOINT mkdir /output && mv /instance.json /output/instance.json && sleep 6000
+ENTRYPOINT mkdir /output; mv /instance.json /output/instance.json && sleep 6000

--- a/tests/testsproblem/generator_timeout/instance.json
+++ b/tests/testsproblem/generator_timeout/instance.json
@@ -1,0 +1,3 @@
+{
+    "semantics": true
+}

--- a/tests/testsproblem/solver_timeout/Dockerfile
+++ b/tests/testsproblem/solver_timeout/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # causes an execution timeout.
 COPY solution.json /solution.json
-ENTRYPOINT mkdir /output && mv /solution.json /output/solution.json && sleep 6000
+ENTRYPOINT mkdir /output; mv /solution.json /output/solution.json && sleep 6000

--- a/tests/testsproblem/solver_timeout/Dockerfile
+++ b/tests/testsproblem/solver_timeout/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 # causes an execution timeout.
 COPY solution.json /solution.json
-ENTRYPOINT mv /solution.json /output/solution.json && sleep 6000
+ENTRYPOINT mkdir /output && mv /solution.json /output/solution.json && sleep 6000

--- a/tests/testsproblem/solver_timeout/Dockerfile
+++ b/tests/testsproblem/solver_timeout/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine
 
 # causes an execution timeout.
-ENTRYPOINT sleep 6000
+COPY solution.json /solution.json
+ENTRYPOINT mv /solution.json /output/solution.json && sleep 6000

--- a/tests/testsproblem/solver_timeout/solution.json
+++ b/tests/testsproblem/solver_timeout/solution.json
@@ -1,0 +1,4 @@
+{
+    "semantics": true,
+    "quality": true
+}


### PR DESCRIPTION
This PR lets you choose what happens when a container doesn't finish executing within the available time but does produce valid output. By default the containers are simply stopped at the end of the time limit, no error is raised. When the `strict_timeouts` options is set they will instead be considered to have failed even if the contents of the output folder might be correct.