### PR TITLE
Add docker image size limit

### DIFF
--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -74,7 +74,7 @@ def client() -> DockerClient:
 
 def set_docker_config(config: DockerConfig) -> None:
     """Sets up the static docker config attributes.
-    
+
     Various classes in the docker_util module need statically set config options, e.g. advanced build/run arguments or
     the strict_timeout option. This function propagates initializes all of these correctly.
     """
@@ -444,11 +444,7 @@ class Program(ABC):
             except ExecutionTimeout as e:
                 if self.docker_config.strict_timeouts:
                     return result_class(
-                        ProgramRunInfo(
-                            params=run_params,
-                            runtime=e.runtime,
-                            error=ExceptionInfo.from_exception(e)
-                        )
+                        ProgramRunInfo(params=run_params, runtime=e.runtime, error=ExceptionInfo.from_exception(e))
                     )
                 else:
                     runtime = e.runtime


### PR DESCRIPTION
This just adds an option to limit the size of the build docker images. This looks at the final docker image size after all dependencies etc are included. This means that it will overestimate the actual disk space used since it overcounts shared images.  
E.g. if there are two teams each using the 5GB (made up numbers) big python image as their base and then include 1 GB of their own code in both their generators and solvers we would consider each image to be 6GB big, even though only 9GB of disk space are used by docker in total.

I don't think there is a good way to track the actual size of the image on disk, but I think tracking it like this also is the most fair since it won't lead to discrepancies based on what images already happen to be installed or what team was the first to use a particular base.