### PR TITLE
Let users install problems

### DIFF
--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -54,8 +54,9 @@ def parse_cli_args(args: list[str]) -> tuple[CliOptions, MatchConfig]:
     except KeyError:
         problem_path = Path(parsed.problem)
         if not problem_path.exists():
-            raise ValueError(f"Passed problem option '{parsed.problem}' is neither the name of an installed problem "
-                             "nor a path to one.")
+            raise ValueError(
+                f"Passed argument '{parsed.problem}' is neither the name of an installed problem nor a path to one."
+            )
         problem = Problem.import_from_path(problem_path)
         base_path = problem_path
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -48,10 +48,11 @@ def parse_cli_args(args: list[str]) -> tuple[CliOptions, MatchConfig]:
     )
 
     parsed = parser.parse_args(args)
-    try:
-        problem = Problem.all()[parsed.problem]
+    installed_problems = Problem.all()
+    if parsed.problem in installed_problems:
+        problem = installed_problems[parsed.problem]
         base_path = Path()
-    except KeyError:
+    else:
         problem_path = Path(parsed.problem)
         if not problem_path.exists():
             raise ValueError(

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -73,7 +73,7 @@ def client() -> DockerClient:
 
 def set_docker_config(config: DockerConfig) -> None:
     """Sets up the static docker config attributes.
-    
+
     Various classes in the docker_util module need statically set config options, e.g. advanced build/run arguments or
     the strict_timeout option. This function propagates initializes all of these correctly.
     """
@@ -432,11 +432,7 @@ class Program(ABC):
             except ExecutionTimeout as e:
                 if self.docker_config.strict_timeouts:
                     return result_class(
-                        ProgramRunInfo(
-                            params=run_params,
-                            runtime=e.runtime,
-                            error=ExceptionInfo.from_exception(e)
-                        )
+                        ProgramRunInfo(params=run_params, runtime=e.runtime, error=ExceptionInfo.from_exception(e))
                     )
                 else:
                     runtime = e.runtime

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -134,8 +134,6 @@ class Problem(Encodable, ABC):
         """
         if path.is_file():
             pass
-        elif (path / "__init__.py").is_file():
-            path /= "__init__.py"
         elif (path / "problem.py").is_file():
             path /= "problem.py"
         else:

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -168,8 +168,6 @@ class Problem(Encodable, ABC):
                 problem_cls.Solution.update_forward_refs()
             return problem_cls
 
-        except Exception as e:
-            raise ValueError from e
         finally:
             sys.modules.pop("_problem")
 

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -283,6 +283,8 @@ Weight = TypeVar("Weight")
 class EdgeWeights(DirectedGraph, GenericModel, Generic[Weight]):
     """Mixin for graphs with weighted edges."""
 
+    export: ClassVar[bool] = False
+
     edge_weights: list[Weight]
 
     def validate_instance(self, size: int):
@@ -294,6 +296,8 @@ class EdgeWeights(DirectedGraph, GenericModel, Generic[Weight]):
 
 class VertexWeights(DirectedGraph, GenericModel, Generic[Weight]):
     """Mixin for graphs with weighted vertices."""
+
+    export: ClassVar[bool] = False
 
     vertex_weights: list[Weight]
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -204,17 +204,17 @@ class Parsing(TestCase):
 
     def test_no_cfg_default(self):
         options, cfg = parse_cli_args([str(self.problem_path)])
-        self.assertEqual(options, CliOptions(self.problem_path))
+        self.assertEqual(options, CliOptions(TestProblem))
         self.assertEqual(cfg, MatchConfig(teams=self.teams))
 
     def test_empty_cfg(self):
         options, cfg = parse_cli_args([str(self.problem_path), "--config", str(self.configs_path / "empty.toml")])
-        self.assertEqual(options, CliOptions(self.problem_path))
+        self.assertEqual(options, CliOptions(TestProblem))
         self.assertEqual(cfg, MatchConfig(teams=self.teams))
 
     def test_cfg(self):
         problem, cfg = parse_cli_args([str(self.problem_path), "--config", str(self.configs_path / "test.toml")])
-        self.assertEqual(problem, CliOptions(self.problem_path))
+        self.assertEqual(problem, CliOptions(TestProblem))
         self.assertEqual(
             cfg,
             MatchConfig(
@@ -230,7 +230,7 @@ class Parsing(TestCase):
 
     def test_cli(self):
         options, _ = parse_cli_args([str(self.problem_path), "-s"])
-        self.assertEqual(options, CliOptions(self.problem_path, silent=True))
+        self.assertEqual(options, CliOptions(TestProblem, silent=True))
 
     def test_cli_no_problem_path(self):
         with self.assertRaises(SystemExit):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -203,18 +203,15 @@ class Parsing(TestCase):
         ]
 
     def test_no_cfg_default(self):
-        options, cfg = parse_cli_args([str(self.problem_path)])
-        self.assertEqual(options, CliOptions(TestProblem))
+        _, cfg = parse_cli_args([str(self.problem_path)])
         self.assertEqual(cfg, MatchConfig(teams=self.teams))
 
     def test_empty_cfg(self):
-        options, cfg = parse_cli_args([str(self.problem_path), "--config", str(self.configs_path / "empty.toml")])
-        self.assertEqual(options, CliOptions(TestProblem))
+        _, cfg = parse_cli_args([str(self.problem_path), "--config", str(self.configs_path / "empty.toml")])
         self.assertEqual(cfg, MatchConfig(teams=self.teams))
 
     def test_cfg(self):
-        problem, cfg = parse_cli_args([str(self.problem_path), "--config", str(self.configs_path / "test.toml")])
-        self.assertEqual(problem, CliOptions(TestProblem))
+        _, cfg = parse_cli_args([str(self.problem_path), "--config", str(self.configs_path / "test.toml")])
         self.assertEqual(
             cfg,
             MatchConfig(
@@ -229,8 +226,8 @@ class Parsing(TestCase):
         )
 
     def test_cli(self):
-        options, _ = parse_cli_args([str(self.problem_path), "-s"])
-        self.assertEqual(options, CliOptions(TestProblem, silent=True))
+        exec_config, _ = parse_cli_args([str(self.problem_path), "-s"])
+        self.assertTrue(exec_config.silent)
 
     def test_cli_no_problem_path(self):
         with self.assertRaises(SystemExit):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -3,7 +3,7 @@
 from unittest import IsolatedAsyncioTestCase, TestCase, main
 from pathlib import Path
 
-from algobattle.cli import CliOptions, parse_cli_args
+from algobattle.cli import parse_cli_args
 from algobattle.battle import Fight, Iterated, Averaged
 from algobattle.match import MatchConfig, Match
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo

--- a/tests/testsproblem/__init__.py
+++ b/tests/testsproblem/__init__.py
@@ -1,1 +1,5 @@
 """Module containing the test problem and programs."""
+
+from .problem import TestProblem
+
+__all__ = ["TestProblem"]


### PR DESCRIPTION
This uses entrypoints similar to the ones for battle types to let people install problems and their dependencies. If you want to distribute a problem with some depency you can then just package it as a python project (with a `pyproject.toml`, `setup.py`, or similar file) and have the user install that package through pip. The problem package should expose the problem class as an endpoint like so:
```toml
[project.entry-points."algobattle.problem"]
ProblemName = "package_name.module_name:ProblemClass"
```

You can then run `algobattle ProblemName` to run a match with that problem instead of a path to the problem file.  
Using paths to problem files still is supported, both for installed problems and to run uninstalled problems.

We could also create a subcommand like `algobattle install problem/path` to install problems without the user having to invoke pip. But I think that's not needed since it would literally just change the name of the command they need to run and [pip heavily discourages users from calling it from other python code](https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program)