### PR TITLE
Switch to official docker build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,13 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # we need to use a fixed version of the docker lib for windows
-    "docker @ git+https://github.com/ImogenBits/docker-py.git@windows_timeouts",
-
-    # on windows, we need to manually install curses bindings
-    "windows-curses; os_name == 'nt'",
-
+    "docker",
     "prettytable",
     "pydantic < 2",
     "anyio",
+
+    # on windows, we need to manually install curses bindings
+    "windows-curses; os_name == 'nt'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
My docker PR has been merged and is now included in the [official docker-py release](https://github.com/docker/docker-py/releases/tag/6.1.2). This also fixes the resource leak issues we were seeing.