### PR TITLE
Cleanup config files

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -362,8 +362,10 @@ class Averaged(Battle):
 
     @inherit_docs
     class BattleConfig(Battle.BattleConfig):
-        instance_size: int = Field(default=10, help="Instance size that will be fought at.")
-        num_fights: int = Field(default=10, help="Number of iterations in each round.")
+        instance_size: int = 10
+        """Instance size that will be fought at."""
+        num_fights: int = 10
+        """Number of iterations in each round."""
 
     @inherit_docs
     class UiData(Battle.UiData):

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -287,12 +287,12 @@ class Iterated(Battle):
     class BattleConfig(Battle.BattleConfig):
         rounds: int = 5
         """Number of times the instance size will be increased until the solver fails to produce correct solutions."""
-        iteration_cap: int = 50_000
+        maximum_size: int = 50_000
         """Maximum instance size that will be tried."""
         exponent: int = 2
         """Determines how quickly the instance size grows."""
-        approximation_ratio: float = 1
-        """Approximation ratio that a solver needs to achieve to pass."""
+        minimum_score: float = 1
+        """Minimum score that a solver needs to achieve in order to pass."""
 
     @inherit_docs
     class UiData(Battle.UiData):
@@ -315,13 +315,13 @@ class Iterated(Battle):
             base_increment = 0
             alive = True
             reached = 0
-            cap = config.iteration_cap
+            cap = config.maximum_size
             current = min_size
             while alive:
                 ui.update_data(self.UiData(reached=self.results + [reached], cap=cap))
                 result = await fight.run(current)
                 score = result.score
-                if score < config.approximation_ratio:
+                if score < config.minimum_score:
                     alive = False
 
                 if not alive and base_increment > 1:
@@ -363,7 +363,7 @@ class Averaged(Battle):
     @inherit_docs
     class BattleConfig(Battle.BattleConfig):
         instance_size: int = Field(default=10, help="Instance size that will be fought at.")
-        iterations: int = Field(default=10, help="Number of iterations in each round.")
+        num_fights: int = Field(default=10, help="Number of iterations in each round.")
 
     @inherit_docs
     class UiData(Battle.UiData):
@@ -376,7 +376,7 @@ class Averaged(Battle):
         """
         if config.instance_size < min_size:
             raise ValueError(f"size {config.instance_size} is smaller than the smallest valid size, {min_size}.")
-        for i in range(config.iterations):
+        for i in range(config.num_fights):
             ui.update_data(self.UiData(round=i + 1))
             await fight.run(config.instance_size)
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -77,13 +77,7 @@ def parse_cli_args(args: list[str]) -> tuple[CliOptions, BaseConfig]:
         config = BaseConfig()
 
     if not config.teams:
-        config.teams.append(
-            TeamInfo(
-                name="team_0",
-                generator=base_path / "generator",
-                solver=base_path / "solver",
-            )
-        )
+        config.teams["team_0"] = TeamInfo(generator=base_path / "generator", solver=base_path / "solver")
 
     return exec_config, config
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -30,7 +30,7 @@ class CliOptions:
 
     problem: type[Problem]
     silent: bool = False
-    result_output: Path | None = None
+    result: Path | None = None
 
 
 def parse_cli_args(args: list[str]) -> tuple[CliOptions, BaseConfig]:
@@ -65,7 +65,7 @@ def parse_cli_args(args: list[str]) -> tuple[CliOptions, BaseConfig]:
     exec_config = CliOptions(
         problem=problem,
         silent=parsed.silent,
-        result_output=parsed.result_output,
+        result=parsed.result,
     )
     cfg_path: Path = parsed.config or base_path / "config.toml"
 
@@ -107,10 +107,10 @@ def main():
             for team, pts in points.items():
                 print(f"Team {team} gained {pts:.1f} points.")
 
-        if exec_config.result_output is not None:
+        if exec_config.result is not None:
             t = datetime.now()
             filename = f"{t.year:04d}-{t.month:02d}-{t.day:02d}_{t.hour:02d}-{t.minute:02d}-{t.second:02d}.json"
-            with open(exec_config.result_output / filename, "w+") as f:
+            with open(exec_config.result / filename, "w+") as f:
                 f.write(result.json())
 
     except KeyboardInterrupt:

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -18,7 +18,7 @@ from anyio.abc import TaskGroup
 
 from algobattle.battle import Battle, Fight
 from algobattle.docker_util import GeneratorResult, ProgramRunInfo, SolverResult
-from algobattle.match import MatchConfig, Match, Ui
+from algobattle.match import BaseConfig, Match, Ui
 from algobattle.problem import Problem
 from algobattle.team import Matchup, TeamInfo
 from algobattle.util import Role, TimerInfo, check_path, flat_intersperse
@@ -33,7 +33,7 @@ class CliOptions:
     result_output: Path | None = None
 
 
-def parse_cli_args(args: list[str]) -> tuple[CliOptions, MatchConfig]:
+def parse_cli_args(args: list[str]) -> tuple[CliOptions, BaseConfig]:
     """Parse a given CLI arg list into config objects."""
     parser = ArgumentParser()
     parser.add_argument("problem", help="Either the name of an installed problem, or a path to a problem file.")
@@ -70,11 +70,11 @@ def parse_cli_args(args: list[str]) -> tuple[CliOptions, MatchConfig]:
 
     if cfg_path.is_file():
         try:
-            config = MatchConfig.from_file(cfg_path)
+            config = BaseConfig.from_file(cfg_path)
         except Exception as e:
             raise ValueError(f"Invalid config file, terminating execution.\n{e}")
     else:
-        config = MatchConfig()
+        config = BaseConfig()
 
     if not config.teams:
         config.teams.append(
@@ -89,7 +89,7 @@ def parse_cli_args(args: list[str]) -> tuple[CliOptions, MatchConfig]:
 
 
 async def _run_with_ui(
-    match_config: MatchConfig,
+    match_config: BaseConfig,
     problem: type[Problem],
 ) -> Match:
     async with CliUi() as ui:
@@ -107,8 +107,8 @@ def main():
             result = run(_run_with_ui, config, exec_config.problem)
         print("\n".join(CliUi.display_match(result)))
 
-        if config.points > 0:
-            points = result.calculate_points(config.points)
+        if config.match.points > 0:
+            points = result.calculate_points(config.match.points)
             for team, pts in points.items():
                 print(f"Team {team} gained {pts:.1f} points.")
 

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -39,12 +39,13 @@ def parse_cli_args(args: list[str]) -> tuple[CliOptions, BaseConfig]:
     parser.add_argument("problem", help="Either the name of an installed problem, or a path to a problem file.")
     parser.add_argument(
         "--config",
+        "-c",
         type=partial(check_path, type="file"),
         help="Path to a config file, defaults to '{problem} / config.toml'.",
     )
-    parser.add_argument("-s", "--silent", action="store_true", help="Disable the cli Ui.")
+    parser.add_argument("--silent", "-s", action="store_true", help="Disable the cli Ui.")
     parser.add_argument(
-        "--result_output", type=check_path, help="If set, the match result object will be saved to the specified file."
+        "--result", "-r", type=check_path, help="If set, the match result object will be saved to the specified file."
     )
 
     parsed = parser.parse_args(args)

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -205,7 +205,7 @@ class AdvancedBuildArgs(BaseModel):
         return self.dict(exclude_none=True)
 
 
-class DockerConfig(BaseModel):
+class ProgramConfig(BaseModel):
     """Config options relevant to the way programs are run and built."""
 
     build_timeout: float | None = None
@@ -231,7 +231,7 @@ def client() -> DockerClient:
     return _client_var
 
 
-def set_docker_config(config: DockerConfig) -> None:
+def set_docker_config(config: ProgramConfig) -> None:
     """Sets up the static docker config attributes.
 
     Various classes in the docker_util module need statically set config options, e.g. advanced build/run arguments or
@@ -266,7 +266,7 @@ class Image:
     id: str
     path: Path
 
-    docker_config: ClassVar[DockerConfig] = DockerConfig()
+    docker_config: ClassVar[ProgramConfig] = ProgramConfig()
 
     run_kwargs: ClassVar[dict[str, Any]] = {
         "network_mode": "none",
@@ -528,7 +528,7 @@ class Program(ABC):
     """The problem this program creates instances and/or solutions for."""
 
     role: ClassVar[Role]
-    docker_config: ClassVar[DockerConfig] = DockerConfig()
+    docker_config: ClassVar[ProgramConfig] = ProgramConfig()
 
     @classmethod
     async def build(

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -40,7 +40,6 @@ _client_var: DockerClient | None = None
 
 def parse_zero_to_none(cls, value):
     """Used as a validator to parse 0 values into Python None objects."""
-
     return None if value == 0 else value
 
 
@@ -230,6 +229,7 @@ class ProgramConfig(BaseModel):
     @validator("set_cpus")
     def _parse_empty_str(cls, value):
         return None if value == "" else value
+
 
 def client() -> DockerClient:
     """Returns the docker api client, checking that it's still responsive."""

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -56,7 +56,7 @@ class BaseConfig(BaseModel):
     @validator("program")
     def val_set_cpus(cls, v: ProgramConfig, values) -> ProgramConfig:
         """Validates that each battle that is being executed is assigned some cpu cores."""
-        if isinstance(v.set_cpus, list) and values["parallel_battles"] > len(v.set_cpus):
+        if isinstance(v.set_cpus, list) and values["match"]["parallel_battles"] > len(v.set_cpus):
             raise ValueError("Number of parallel battles exceeds the number of set_cpu specifier strings.")
         else:
             return v

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -17,6 +17,7 @@ from algobattle.team import Matchup, Team, TeamHandler, TeamInfo
 from algobattle.problem import Problem
 from algobattle.util import MatchMode, Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
 
+
 class MatchConfig(BaseModel):
     """Parameters determining the match execution."""
 
@@ -32,6 +33,7 @@ class MatchConfig(BaseModel):
             return value
         else:
             raise ValueError
+
 
 class BaseConfig(BaseModel):
     """Base that contains all config options and can be parsed from config files."""

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -23,7 +23,7 @@ class MatchConfig(BaseModel):
     battle_type: str = "Iterated"
     points: int = 100
     parallel_battles: int = 1
-    mode: MatchMode = "tournament"
+    mode: MatchMode = "testing"
 
     @validator("battle_type", pre=True)
     def validate_battle_type(cls, value):

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -13,7 +13,7 @@ from anyio.to_thread import current_default_thread_limiter
 
 from algobattle.battle import Battle, FightHandler, FightUiProxy, BattleUiProxy
 from algobattle.docker_util import ProgramConfig, ProgramRunInfo, ProgramUiProxy, set_docker_config
-from algobattle.team import Matchup, Team, TeamHandler, TeamInfo
+from algobattle.team import Matchup, Team, TeamHandler, TeamInfos
 from algobattle.problem import Problem
 from algobattle.util import MatchMode, Role, TimerInfo, inherit_docs, BaseModel, str_with_traceback
 
@@ -38,7 +38,7 @@ class MatchConfig(BaseModel):
 class BaseConfig(BaseModel):
     """Base that contains all config options and can be parsed from config files."""
 
-    teams: list[TeamInfo] = []
+    teams: TeamInfos = {}
     match: MatchConfig = MatchConfig()
     program: ProgramConfig = ProgramConfig()
     battle: dict[str, Battle.BattleConfig] = {n: b.BattleConfig() for n, b in Battle.all().items()}

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -39,7 +39,7 @@ class TeamInfo(BaseModel):
         """Builds the specified docker files into images and return the corresponding team.
 
         Args:
-            name: Name of the team. Will be normalized to fit docker tag requirements.
+            name: Name of the team.
             problem: The problem class the current match is fought over.
             config: Config for the current match.
             name_programs: Whether the programs should be given deterministic names.
@@ -53,13 +53,13 @@ class TeamInfo(BaseModel):
         """
         if name in _team_names:
             raise ValueError
-        image_name = name if name_programs else None
+        tag_name = name.lower().replace(" ", "_") if name_programs else None
         ui.start_build(name, "generator", config.build_timeout)
-        generator = await Generator.build(self.generator, problem, config.generator, config.build_timeout, image_name)
+        generator = await Generator.build(self.generator, problem, config.generator, config.build_timeout, tag_name)
         ui.finish_build()
         try:
             ui.start_build(name, "solver", config.build_timeout)
-            solver = await Solver.build(self.solver, problem, config.solver, config.build_timeout, image_name)
+            solver = await Solver.build(self.solver, problem, config.solver, config.build_timeout, tag_name)
             ui.finish_build()
         except Exception:
             generator.remove()

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -5,7 +5,7 @@ from itertools import combinations
 from pathlib import Path
 from typing import Iterator, Protocol, Self
 
-from algobattle.docker_util import DockerConfig, Generator, Solver
+from algobattle.docker_util import ProgramConfig, Generator, Solver
 from algobattle.problem import Problem
 from algobattle.util import ExceptionInfo, MatchMode, Role
 
@@ -34,7 +34,7 @@ class TeamInfo:
     solver: Path
 
     async def build(
-        self, problem: type[Problem], config: DockerConfig, name_programs: bool, ui: BuildUiProxy
+        self, problem: type[Problem], config: ProgramConfig, name_programs: bool, ui: BuildUiProxy
     ) -> "Team":
         """Builds the specified docker files into images and return the corresponding team.
 
@@ -137,7 +137,7 @@ class TeamHandler:
 
     @classmethod
     async def build(
-        cls, infos: list[TeamInfo], problem: type[Problem], mode: MatchMode, config: DockerConfig, ui: BuildUiProxy
+        cls, infos: list[TeamInfo], problem: type[Problem], mode: MatchMode, config: ProgramConfig, ui: BuildUiProxy
     ) -> Self:
         """Builds the programs of every team.
 

--- a/tests/configs/teams.toml
+++ b/tests/configs/teams.toml
@@ -1,9 +1,7 @@
-[[teams]]
-name = "team 1"
+[teams."team 1"]
 generator = "."
 solver = "."
 
-[[teams]]
-name = "team 2"
+[teams."team 2"]
 generator = "."
 solver = "."

--- a/tests/configs/teams_incorrect.toml
+++ b/tests/configs/teams_incorrect.toml
@@ -1,8 +1,6 @@
-[[teams]]
-name = "team 1"
+[teams."team 1"]
 generator = "."
 solver = "."
 
-[[teams]]
-generator = "."
+[teams."team 2"]
 solver = "."

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -4,5 +4,5 @@ battle_type = "Averaged"
 [program.generator]
 space = 10
 
-[program.Averaged]
-iterations = 1
+[battle.Averaged]
+num_fights = 1

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,8 +1,8 @@
 points = 10
 battle_type = "Averaged"
 
-[docker.generator]
+[program.generator]
 space = 10
 
-[battle.Averaged]
+[program.Averaged]
 iterations = 1

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,3 +1,4 @@
+[match]
 points = 10
 battle_type = "Averaged"
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -169,19 +169,19 @@ class Execution(IsolatedAsyncioTestCase):
         cls.solver = problem_path / "solver"
 
     async def test_basic(self):
-        self.config.teams = [TeamInfo("team_0", self.generator, self.solver)]
+        self.config.teams = {"team_0": TeamInfo(generator=self.generator, solver=self.solver)}
         self.config.match.battle_type = "Iterated"
         await Match.run(self.config, TestProblem)
 
     async def test_multi_team(self):
-        team0 = TeamInfo("team_0", self.generator, self.solver)
-        team1 = TeamInfo("team_1", self.generator, self.solver)
-        self.config.teams = [team0, team1]
+        team0 = TeamInfo(generator=self.generator, solver=self.solver)
+        team1 = TeamInfo(generator=self.generator, solver=self.solver)
+        self.config.teams = {"team_0": team0, "team_1": team1}
         self.config.match.battle_type = "Iterated"
         await Match.run(self.config, TestProblem)
 
     async def test_averaged(self):
-        self.config.teams = [TeamInfo("team_0", self.generator, self.solver)]
+        self.config.teams = {"team_0": TeamInfo(generator=self.generator, solver=self.solver)}
         self.config.match.battle_type = "Averaged"
         await Match.run(self.config, TestProblem)
 
@@ -194,13 +194,9 @@ class Parsing(TestCase):
         path = Path(__file__).parent
         cls.problem_path = path / "testsproblem"
         cls.configs_path = path / "configs"
-        cls.teams = [
-            TeamInfo(
-                name="team_0",
-                generator=cls.problem_path / "generator",
-                solver=cls.problem_path / "solver",
-            )
-        ]
+        cls.teams = {
+            "team_0": TeamInfo(generator=cls.problem_path / "generator", solver=cls.problem_path / "solver")
+        }
 
     def test_no_cfg_default(self):
         _, cfg = parse_cli_args([str(self.problem_path)])
@@ -238,7 +234,10 @@ class Parsing(TestCase):
     def test_cfg_team(self):
         _, cfg = parse_cli_args([str(self.problem_path), f"--config={self.configs_path / 'teams.toml'}"])
         self.assertEqual(
-            cfg, BaseConfig(teams=[TeamInfo("team 1", Path(), Path()), TeamInfo("team 2", Path(), Path())])
+            cfg, BaseConfig(teams={
+                "team 1": TeamInfo(generator=Path(), solver=Path()),
+                "team 2": TeamInfo(generator=Path(), solver=Path()),
+            })
         )
 
     def test_cfg_team_no_name(self):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -161,8 +161,8 @@ class Execution(IsolatedAsyncioTestCase):
         cls.config = BaseConfig(
             program=ProgramConfig(generator=run_params, solver=run_params),
             battle={
-                "Iterated": Iterated.BattleConfig(iteration_cap=10, rounds=2),
-                "Averaged": Averaged.BattleConfig(instance_size=5, iterations=3),
+                "Iterated": Iterated.BattleConfig(maximum_size=10, rounds=2),
+                "Averaged": Averaged.BattleConfig(instance_size=5, num_fights=3),
             },
         )
         cls.generator = problem_path / "generator"
@@ -222,7 +222,7 @@ class Parsing(TestCase):
                 ),
                 program=ProgramConfig(generator=RunParameters(space=10)),
                 battle={
-                    "Averaged": Averaged.BattleConfig(iterations=1),
+                    "Averaged": Averaged.BattleConfig(num_fights=1),
                 },
             ),
         )

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -194,9 +194,7 @@ class Parsing(TestCase):
         path = Path(__file__).parent
         cls.problem_path = path / "testsproblem"
         cls.configs_path = path / "configs"
-        cls.teams = {
-            "team_0": TeamInfo(generator=cls.problem_path / "generator", solver=cls.problem_path / "solver")
-        }
+        cls.teams = {"team_0": TeamInfo(generator=cls.problem_path / "generator", solver=cls.problem_path / "solver")}
 
     def test_no_cfg_default(self):
         _, cfg = parse_cli_args([str(self.problem_path)])
@@ -234,10 +232,13 @@ class Parsing(TestCase):
     def test_cfg_team(self):
         _, cfg = parse_cli_args([str(self.problem_path), f"--config={self.configs_path / 'teams.toml'}"])
         self.assertEqual(
-            cfg, BaseConfig(teams={
-                "team 1": TeamInfo(generator=Path(), solver=Path()),
-                "team 2": TeamInfo(generator=Path(), solver=Path()),
-            })
+            cfg,
+            BaseConfig(
+                teams={
+                    "team 1": TeamInfo(generator=Path(), solver=Path()),
+                    "team 2": TeamInfo(generator=Path(), solver=Path()),
+                }
+            ),
         )
 
     def test_cfg_team_no_name(self):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -7,7 +7,7 @@ from algobattle.cli import parse_cli_args
 from algobattle.battle import Fight, Iterated, Averaged
 from algobattle.match import BaseConfig, Match, MatchConfig
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo
-from algobattle.docker_util import DockerConfig, ProgramRunInfo, RunParameters
+from algobattle.docker_util import ProgramConfig, ProgramRunInfo, RunParameters
 from .testsproblem.problem import TestProblem
 
 
@@ -159,7 +159,7 @@ class Execution(IsolatedAsyncioTestCase):
         cls.problem = TestProblem
         run_params = RunParameters(timeout=2)
         cls.config = BaseConfig(
-            docker=DockerConfig(generator=run_params, solver=run_params),
+            program=ProgramConfig(generator=run_params, solver=run_params),
             battle={
                 "Iterated": Iterated.BattleConfig(iteration_cap=10, rounds=2),
                 "Averaged": Averaged.BattleConfig(instance_size=5, iterations=3),
@@ -220,7 +220,7 @@ class Parsing(TestCase):
                     points=10,
                     battle_type="Averaged",
                 ),
-                docker=DockerConfig(generator=RunParameters(space=10)),
+                program=ProgramConfig(generator=RunParameters(space=10)),
                 battle={
                     "Averaged": Averaged.BattleConfig(iterations=1),
                 },

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -170,19 +170,19 @@ class Execution(IsolatedAsyncioTestCase):
 
     async def test_basic(self):
         self.config.teams = [TeamInfo("team_0", self.generator, self.solver)]
-        self.config.battle_type = "Iterated"
+        self.config.match.battle_type = "Iterated"
         await Match.run(self.config, TestProblem)
 
     async def test_multi_team(self):
         team0 = TeamInfo("team_0", self.generator, self.solver)
         team1 = TeamInfo("team_1", self.generator, self.solver)
         self.config.teams = [team0, team1]
-        self.config.battle_type = "Iterated"
+        self.config.match.battle_type = "Iterated"
         await Match.run(self.config, TestProblem)
 
     async def test_averaged(self):
         self.config.teams = [TeamInfo("team_0", self.generator, self.solver)]
-        self.config.battle_type = "Averaged"
+        self.config.match.battle_type = "Averaged"
         await Match.run(self.config, TestProblem)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ import unittest
 import random
 from pathlib import Path
 
-from algobattle.match import MatchConfig
+from algobattle.match import BaseConfig
 from algobattle.problem import Problem
 from algobattle.battle import Battle, Iterated, Averaged
 from . import testsproblem
@@ -15,7 +15,7 @@ class Utiltests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Set up a problem, default config, fight handler and get a file name not existing on the file system."""
-        cls.config = MatchConfig()
+        cls.config = BaseConfig()
         cls.problem_path = Path(testsproblem.__file__).parent / "problem.py"
         cls.rand_file_name = str(random.randint(0, 2**80))
         while Path(cls.rand_file_name).exists():


### PR DESCRIPTION
This cleanes up a bunch of stuff in the config files. Renaming some parameters to be more expressive, removing unneeded complexity in the parsing process, and using 0 as a sentinel value to indicate that a timeout/memory limit is ignored since toml doesn't have a built in None/null/etc type.

Note that the vast majority of this PR's git diff is just caused by moving two classes from the bottom of the docker_utils module to the top.