### PR TITLE
Fix Match.excluded_teams

### DIFF
--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -234,7 +234,7 @@ class DockerError(AlgobattleBaseException):
 
 
 class ExceptionInfo(BaseModel):
-    """An exception that can be encoded into a json file."""
+    """Details about an exception that was raised."""
 
     type: str
     message: str


### PR DESCRIPTION
This fixes a small bug where the match output didn't actually store the errors that were thrown during the build process of docker images.