### PR TITLE
Better error message if trying to decode nonexistent file

### DIFF
--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -135,6 +135,8 @@ class EncodableModel(BaseModel, Encodable, ABC):
     @classmethod
     def decode(cls, source: Path, size: int, team: Role) -> Self:
         """Uses pydantic to create a python object from a `.json` file."""
+        if not source.with_suffix(".json").is_file():
+            raise EncodingError("The json file does not exist.")
         try:
             return cls.parse_file(source.with_suffix(".json"))
         except PydanticValidationError as e:


### PR DESCRIPTION
This just creates a more informative error message when trying to decode a nonexistent file, as usually happens when a program didnt create any output.