### PR TITLE
Clarify problem size

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -169,7 +169,7 @@ class FightHandler:
             return self._saved(Fight(score=0, max_size=max_size, generator=gen_result.info, solver=sol_result.info))
 
         score = gen_result.instance.calculate_score(
-            solution=sol_result.solution, generator_solution=gen_result.solution, max_size=max_size
+            solution=sol_result.solution, generator_solution=gen_result.solution
         )
         score = max(0, min(1, float(score)))
         return self._saved(Fight(score=score, max_size=max_size, generator=gen_result.info, solver=sol_result.info))

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -62,7 +62,7 @@ class FightUiProxy(Protocol):
     solver: ProgramUiProxy
 
     @abstractmethod
-    def start(self, size: int) -> None:
+    def start(self, max_size: int) -> None:
         """Informs the ui that a new fight has been started."""
 
     @abstractmethod
@@ -91,7 +91,7 @@ class FightHandler:
 
     async def run(
         self,
-        size: int,
+        max_size: int,
         *,
         timeout_generator: float | None = ...,
         space_generator: int | None = ...,
@@ -112,7 +112,7 @@ class FightHandler:
         unset results in the config options being used.
 
         Args:
-            size: The instance size the fight is fought at.
+            max_size: The maximum instance size the generator is allowed to create.
             timeout_generator: Timeout in seconds for the generator to finish running. `None` means it is given an
                 unlimited amount of time.
             space_generator: Memory space in MB the generator has access to. `None` means it is given an unlimited
@@ -132,15 +132,15 @@ class FightHandler:
             The resulting info about the executed fight.
         """
         min_size = self._generator.problem_class.min_size
-        if size < min_size:
+        if max_size < min_size:
             raise ValueError(
-                f"Cannot run battle at size {size} since it is smaller than the smallest "
+                f"Cannot run battle at size {max_size} since it is smaller than the smallest "
                 "size the problem allows ({min_size})."
             )
         ui = self._ui
-        ui.start(size)
+        ui.start(max_size)
         gen_result = await self._generator.run(
-            size=size,
+            max_size=max_size,
             timeout=timeout_generator,
             space=space_generator,
             cpus=cpus_generator,
@@ -151,11 +151,11 @@ class FightHandler:
         )
         ui.update("generator", gen_result.info)
         if gen_result.instance is None:
-            return self._saved(Fight(score=1, max_size=size, generator=gen_result.info, solver=None))
+            return self._saved(Fight(score=1, max_size=max_size, generator=gen_result.info, solver=None))
 
         sol_result = await self._solver.run(
             gen_result.instance,
-            size=size,
+            max_size=max_size,
             timeout=timeout_solver,
             space=space_solver,
             cpus=cpus_solver,
@@ -166,13 +166,13 @@ class FightHandler:
         )
         ui.update("solver", sol_result.info)
         if sol_result.solution is None:
-            return self._saved(Fight(score=0, max_size=size, generator=gen_result.info, solver=sol_result.info))
+            return self._saved(Fight(score=0, max_size=max_size, generator=gen_result.info, solver=sol_result.info))
 
         score = gen_result.instance.calculate_score(
-            solution=sol_result.solution, generator_solution=gen_result.solution, size=size
+            solution=sol_result.solution, generator_solution=gen_result.solution, max_size=max_size
         )
         score = max(0, min(1, float(score)))
-        return self._saved(Fight(score=score, max_size=size, generator=gen_result.info, solver=sol_result.info))
+        return self._saved(Fight(score=score, max_size=max_size, generator=gen_result.info, solver=sol_result.info))
 
 
 # We need this to be here to prevent an import cycle between match.py and battle.py

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -47,8 +47,8 @@ class Fight(BaseModel):
 
     Always a number in [0, 1]. 0 indicates a total failure of the solver, 1 that it succeeded perfectly.
     """
-    size: int
-    """The size the fight was executed at."""
+    max_size: int
+    """The maximum size of an instance the generator was allowed to create."""
     generator: ProgramRunInfo
     """Data about the generator's execution."""
     solver: ProgramRunInfo | None
@@ -151,7 +151,7 @@ class FightHandler:
         )
         ui.update("generator", gen_result.info)
         if gen_result.instance is None:
-            return self._saved(Fight(score=1, size=size, generator=gen_result.info, solver=None))
+            return self._saved(Fight(score=1, max_size=size, generator=gen_result.info, solver=None))
 
         sol_result = await self._solver.run(
             gen_result.instance,
@@ -166,13 +166,13 @@ class FightHandler:
         )
         ui.update("solver", sol_result.info)
         if sol_result.solution is None:
-            return self._saved(Fight(score=0, size=size, generator=gen_result.info, solver=sol_result.info))
+            return self._saved(Fight(score=0, max_size=size, generator=gen_result.info, solver=sol_result.info))
 
         score = gen_result.instance.calculate_score(
             solution=sol_result.solution, generator_solution=gen_result.solution, size=size
         )
         score = max(0, min(1, float(score)))
-        return self._saved(Fight(score=score, size=size, generator=gen_result.info, solver=sol_result.info))
+        return self._saved(Fight(score=score, max_size=size, generator=gen_result.info, solver=sol_result.info))
 
 
 # We need this to be here to prevent an import cycle between match.py and battle.py

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -328,7 +328,7 @@ class CliUi(Ui):
             exec_info = ", solver failed!"
         else:
             exec_info = ""
-        return f"Fight {index} at size {fight.size}: {fight.score}{exec_info}"
+        return f"Fight {index} at size {fight.max_size}: {fight.score}{exec_info}"
 
     def display_battle(self, matchup: Matchup) -> list[str]:
         """Formats the battle data into a string that can be printed to the terminal."""

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -143,7 +143,7 @@ class _BuildInfo:
 
 @dataclass
 class _FightUiData:
-    size: int
+    max_size: int
     generator: TimerInfo | float | ProgramRunInfo | None = None
     solver: TimerInfo | float | ProgramRunInfo | None = None
 
@@ -202,9 +202,9 @@ class CliUi(Ui):
         """Passes new custom battle data to the Ui."""
         self.battle_data[matchup] = data
 
-    def start_fight(self, matchup: Matchup, size: int) -> None:
+    def start_fight(self, matchup: Matchup, max_size: int) -> None:
         """Informs the Ui of a newly started fight."""
-        self.fight_data[matchup] = _FightUiData(size, None, None)
+        self.fight_data[matchup] = _FightUiData(max_size, None, None)
 
     def update_curr_fight(
         self,
@@ -314,7 +314,7 @@ class CliUi(Ui):
         """Formats the current fight of a battle into a compact overview."""
         fight = self.fight_data[matchup]
         return [
-            f"Current fight at size {fight.size}:",
+            f"Current fight at size {fight.max_size}:",
             self.display_program("generator", fight.generator),
             self.display_program("solver", fight.solver),
         ]

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -627,7 +627,7 @@ class Program(ABC):
                 )
             if battle_input is not None:
                 try:
-                    battle_input.encode(input / "battle_data", max_size, self.role)
+                    battle_input.encode(input / "battle_data", self.role)
                 except Exception as e:
                     return result_class(
                         ProgramRunInfo(
@@ -731,7 +731,7 @@ class Generator(Program):
         except Exception as e:
             raise EncodingError("Error thrown while decoding the problem instance.", detail=str(e)) from e
         try:
-            problem.validate_instance(max_size)
+            problem.validate_instance()
         except ValidationError:
             raise
         except Exception as e:
@@ -745,7 +745,7 @@ class Generator(Program):
             except Exception as e:
                 raise EncodingError("Error thrown while decoding the solution.", detail=str(e)) from e
             try:
-                solution.validate_solution(problem, max_size)
+                solution.validate_solution(problem)
             except ValidationError:
                 raise
             except Exception as e:
@@ -805,7 +805,7 @@ class Solver(Program):
 
     def _encode_input(self, input: Path, output: Path, max_size: int, instance: Problem | None) -> None:
         assert instance is not None
-        instance.encode(input / "instance", max_size, self.role)
+        instance.encode(input / "instance", self.role)
 
     def _parse_output(self, output: Path, max_size: int, instance: Problem | None) -> Problem.Solution:
         assert instance is not None
@@ -816,7 +816,7 @@ class Solver(Program):
         except Exception as e:
             raise EncodingError("Error thrown while decoding the solution.", detail=str(e)) from e
         try:
-            solution.validate_solution(instance, max_size)
+            solution.validate_solution(instance)
         except ValidationError:
             raise
         except Exception as e:

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -731,7 +731,7 @@ class Generator(Program):
         except Exception as e:
             raise EncodingError("Error thrown while decoding the problem instance.", detail=str(e)) from e
         try:
-            problem.validate_instance()
+            problem.validate_instance(max_size)
         except ValidationError:
             raise
         except Exception as e:

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -730,8 +730,10 @@ class Generator(Program):
             raise
         except Exception as e:
             raise EncodingError("Error thrown while decoding the problem instance.", detail=str(e)) from e
+        if problem.size > max_size:
+            raise EncodingError("Instance is too large.", detail=f"Generated: {problem.size}, maximum: {max_size}")
         try:
-            problem.validate_instance(max_size)
+            problem.validate_instance()
         except ValidationError:
             raise
         except Exception as e:

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -286,7 +286,7 @@ class Ui:
         """Passes new custom battle data to the Ui."""
         return
 
-    def start_fight(self, matchup: Matchup, size: int) -> None:
+    def start_fight(self, matchup: Matchup, max_size: int) -> None:
         """Informs the Ui of a newly started fight."""
         return
 
@@ -327,8 +327,8 @@ class Ui:
             self.solver = Ui.ProgramObserver(self.battle_ui, "solver")
 
         @inherit_docs
-        def start(self, size: int) -> None:
-            self.battle_ui.ui.start_fight(self.battle_ui.matchup, size)
+        def start(self, max_size: int) -> None:
+            self.battle_ui.ui.start_fight(self.battle_ui.matchup, max_size)
 
         @inherit_docs
         def update(

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -39,7 +39,7 @@ class Scored(Protocol):
     """The direction that better scores are found at."""
 
     @abstractmethod
-    def score(self, instance: _Problem, size: int) -> float:
+    def score(self, instance: _Problem, max_size: int) -> float:
         """Calculate the score of this solution for the given problem instance."""
         raise NotImplementedError
 
@@ -71,7 +71,7 @@ class Problem(Encodable, ABC):
             Problem._installed[cls.name] = cls
         return super().__init_subclass__()
 
-    def validate_instance(self, size: int) -> None:
+    def validate_instance(self, max_size: int) -> None:
         """Confirms that the parsed instance is valid.
 
         Should be idempotent, but may also perform additional postprocessing such as bringing the instance
@@ -82,7 +82,7 @@ class Problem(Encodable, ABC):
         """
         return
 
-    def calculate_score(self, solution: _Solution, generator_solution: _Solution | None, size: int) -> float:
+    def calculate_score(self, solution: _Solution, generator_solution: _Solution | None, max_size: int) -> float:
         """Calculates how well a solution solves this problem instance.
 
         There is a default implementation if the solution is :cls:`Scored`. For it, the calculated score is the ratio of
@@ -91,7 +91,7 @@ class Problem(Encodable, ABC):
         Args:
             solution: The solution created by the solver.
             generator_solution: The solution output by the generator, if any.
-            size: The instance size.
+            max_size: The instance size.
 
         Returns:
             The calculated score, a number in [0, 1] with a value of 0 indicating that the solver failed completely and
@@ -99,10 +99,10 @@ class Problem(Encodable, ABC):
         """
         if isinstance(generator_solution, self.Solution) and isinstance(generator_solution, Scored):
             assert isinstance(solution, Scored)
-            gen_score = generator_solution.score(self, size)
+            gen_score = generator_solution.score(self, max_size)
             if gen_score == 0:
                 return 1
-            sol_score = solution.score(self, size)
+            sol_score = solution.score(self, max_size)
             if sol_score == 0:
                 return 0
 
@@ -192,7 +192,7 @@ class Problem(Encodable, ABC):
     class Solution(Encodable, ABC):
         """A proposed solution for an instance of this problem."""
 
-        def validate_solution(self, instance: _Problem, size: int) -> None:
+        def validate_solution(self, instance: _Problem, max_size: int) -> None:
             """Confirms that the parsed solution is valid.
 
             Should be idempotent, but may also perform additional postprocessing such as bringing the solution
@@ -242,9 +242,9 @@ class DirectedGraph(ProblemModel):
     num_vertices: int = Field(ge=0, le=2**63 - 1)
     edges: list[tuple[int, int]] = Field(ge=0, le=2**63 - 1, unique_items=True)
 
-    def validate_instance(self, size: int):
+    def validate_instance(self, max_size: int):
         """Validates that the graph contains at most `size` many vertices and all edges are well defined."""
-        if self.num_vertices > size:
+        if self.num_vertices > max_size:
             raise ValidationError("Graph contains too many vertices.")
         if any(u >= self.num_vertices or v >= self.num_vertices for u, v in self.edges):
             raise ValidationError("Graph contains edges whose endpoints aren't valid vertices")
@@ -255,13 +255,13 @@ class UndirectedGraph(DirectedGraph):
 
     export: ClassVar[bool] = False
 
-    def validate_instance(self, size: int):
+    def validate_instance(self, max_size: int):
         """Validates that the graph is well formed and contains no self loops.
 
         Also brings it into a normal form where every edge {u, v} occurs exactly once in the list.
         I.e. `[(0, 1), (1, 0), (1, 2)]` is accepted as valid and normalised to `[(0, 1), (1, 2)]`.
         """
-        super().validate_instance(size)
+        super().validate_instance(max_size)
         if any(u == v for u, v in self.edges):
             raise ValidationError("Undirected graph contains self loops.")
 
@@ -283,9 +283,9 @@ class EdgeWeights(DirectedGraph, GenericModel, Generic[Weight]):
 
     edge_weights: list[Weight]
 
-    def validate_instance(self, size: int):
+    def validate_instance(self, max_size: int):
         """Validates that each edge has an associated weight."""
-        super().validate_instance(size)
+        super().validate_instance(max_size)
         if len(self.edge_weights) == len(self.edges):
             raise ValidationError("Number of edge weights doesn't match the number of edges.")
 
@@ -297,8 +297,8 @@ class VertexWeights(DirectedGraph, GenericModel, Generic[Weight]):
 
     vertex_weights: list[Weight]
 
-    def validate_instance(self, size: int):
+    def validate_instance(self, max_size: int):
         """Validates that each vertex has an associated weight."""
-        super().validate_instance(size)
+        super().validate_instance(max_size)
         if len(self.vertex_weights) == self.num_vertices:
             raise ValidationError("Number of vertex weights doesn't match the number of vertices.")

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -242,14 +242,14 @@ class DirectedGraph(ProblemModel):
 
     export: ClassVar[bool] = False
 
-    size: int = Field(ge=0, le=2**63 - 1)
+    num_vertices: int = Field(ge=0, le=2**63 - 1)
     edges: list[tuple[int, int]] = Field(ge=0, le=2**63 - 1, unique_items=True)
 
     def validate_instance(self, max_size: int):
         """Validates that the graph contains at most `size` many vertices and all edges are well defined."""
-        if self.size > max_size:
+        if self.num_vertices > max_size:
             raise ValidationError("Graph contains too many vertices.")
-        if any(u >= self.size for edge in self.edges for u in edge):
+        if any(u >= self.num_vertices for edge in self.edges for u in edge):
             raise ValidationError("Graph contains edges whose endpoints aren't valid vertices")
 
 
@@ -303,5 +303,5 @@ class VertexWeights(DirectedGraph, GenericModel, Generic[Weight]):
     def validate_instance(self, max_size: int):
         """Validates that each vertex has an associated weight."""
         super().validate_instance(max_size)
-        if len(self.vertex_weights) != self.size:
+        if len(self.vertex_weights) != self.num_vertices:
             raise ValidationError("Number of vertex weights doesn't match the number of vertices.")

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -62,9 +62,6 @@ class Problem(Encodable, ABC):
     Helps with uniquely specifying a class to be executed in a problem file. For more details view the documentation.
     """
 
-    size: int
-    """Determines the size of a problem instance."""
-
     _installed: ClassVar[dict[str, type["Problem"]]] = {}
 
     def __init_subclass__(cls, export: bool = True) -> None:

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -97,7 +97,6 @@ class Problem(Encodable, ABC):
         Args:
             solution: The solution created by the solver.
             generator_solution: The solution output by the generator, if any.
-            max_size: The instance size.
 
         Returns:
             The calculated score, a number in [0, 1] with a value of 0 indicating that the solver failed completely and

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -82,13 +82,13 @@ class Encodable(ABC):
 
     @classmethod
     @abstractmethod
-    def decode(cls, source: Path, size: int, team: Role) -> Self:
+    def decode(cls, source: Path, max_size: int, team: Role) -> Self:
         """Decodes the data found at the given path into a python object.
 
         Args:
             source: Path to data that can be used to construct an instance of this class. May either point to a folder
                 or a single file. The expected type of path should be consistent with the result of :meth:`.encode`.
-            size: The size of the fight for which this data is being decoded.
+            max_size: The size of the fight for which this data is being decoded.
             team: Role of the team that output the data.
 
         Raises:
@@ -100,14 +100,14 @@ class Encodable(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def encode(self, target: Path, size: int, team: Role) -> None:
+    def encode(self, target: Path, max_size: int, team: Role) -> None:
         """Encodes the object onto the file system so that it can be passed to a program.
 
         Args:
             target: Path to the location where the program expects the encoded data. :meth:`.encode` may either create
                 a single file at the target location, or an entire folder. If creating a single file, it may append a
                 file type ending to the path. It should not affect any other files or directories.
-            size: The size of the data to be encoded.
+            max_size: The size of the data to be encoded.
             team: Role of the team that receives the data.
 
         Raises:
@@ -133,7 +133,7 @@ class EncodableModel(BaseModel, Encodable, ABC):
     """Problem data that can easily be encoded into and decoded from json files."""
 
     @classmethod
-    def decode(cls, source: Path, size: int, team: Role) -> Self:
+    def decode(cls, source: Path, max_size: int, team: Role) -> Self:
         """Uses pydantic to create a python object from a `.json` file."""
         if not source.with_suffix(".json").is_file():
             raise EncodingError("The json file does not exist.")
@@ -144,7 +144,7 @@ class EncodableModel(BaseModel, Encodable, ABC):
         except Exception as e:
             raise EncodingError("Unknown error while decoding the data.", detail=str(e))
 
-    def encode(self, target: Path, size: int, team: Role) -> None:
+    def encode(self, target: Path, max_size: int, team: Role) -> None:
         """Uses pydantic to create a json representation of the object at the targeted file."""
         try:
             with open(target.with_suffix(".json"), "w") as f:

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -100,14 +100,13 @@ class Encodable(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def encode(self, target: Path, max_size: int, team: Role) -> None:
+    def encode(self, target: Path, team: Role) -> None:
         """Encodes the object onto the file system so that it can be passed to a program.
 
         Args:
             target: Path to the location where the program expects the encoded data. :meth:`.encode` may either create
                 a single file at the target location, or an entire folder. If creating a single file, it may append a
                 file type ending to the path. It should not affect any other files or directories.
-            max_size: The size of the data to be encoded.
             team: Role of the team that receives the data.
 
         Raises:
@@ -144,7 +143,7 @@ class EncodableModel(BaseModel, Encodable, ABC):
         except Exception as e:
             raise EncodingError("Unknown error while decoding the data.", detail=str(e))
 
-    def encode(self, target: Path, max_size: int, team: Role) -> None:
+    def encode(self, target: Path, team: Role) -> None:
         """Uses pydantic to create a json representation of the object at the targeted file."""
         try:
             with open(target.with_suffix(".json"), "w") as f:

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -23,7 +23,7 @@ def dummy_result(*score: float) -> list[Fight]:
     return [
         Fight(
             score=s,
-            size=0,
+            max_size=0,
             generator=ProgramRunInfo(
                 params=RunParameters(),
                 runtime=0,

--- a/tests/testsproblem/problem.py
+++ b/tests/testsproblem/problem.py
@@ -17,7 +17,7 @@ class TestProblem(ProblemModel):
         semantics: bool
         quality: bool
 
-        def validate_solution(self, instance: "TestProblem", max_size: int):
+        def validate_solution(self, instance: "TestProblem"):
             if not self.semantics:
                 raise ValidationError("")
 
@@ -27,5 +27,5 @@ class TestProblem(ProblemModel):
         if not self.semantics:
             raise ValidationError("")
 
-    def calculate_score(self, solution: Solution, generator_solution: Solution | None, max_size: int) -> float:
+    def calculate_score(self, solution: Solution, generator_solution: Solution | None) -> float:
         return solution.quality

--- a/tests/testsproblem/problem.py
+++ b/tests/testsproblem/problem.py
@@ -23,7 +23,11 @@ class TestProblem(ProblemModel):
 
     semantics: bool
 
-    def validate_instance(self, max_size: int):
+    @property
+    def size(self) -> int:
+        return 0
+
+    def validate_instance(self):
         if not self.semantics:
             raise ValidationError("")
 

--- a/tests/testsproblem/problem.py
+++ b/tests/testsproblem/problem.py
@@ -17,15 +17,15 @@ class TestProblem(ProblemModel):
         semantics: bool
         quality: bool
 
-        def validate_solution(self, instance: "TestProblem", size: int):
+        def validate_solution(self, instance: "TestProblem", max_size: int):
             if not self.semantics:
                 raise ValidationError("")
 
     semantics: bool
 
-    def validate_instance(self, size: int):
+    def validate_instance(self, max_size: int):
         if not self.semantics:
             raise ValidationError("")
 
-    def calculate_score(self, solution: Solution, generator_solution: Solution | None, size: int) -> float:
+    def calculate_score(self, solution: Solution, generator_solution: Solution | None, max_size: int) -> float:
         return solution.quality


### PR DESCRIPTION
There has been a bit of a discrepancy in the code between the size that a generator is given and the size of the instance it creates. Generally, these are the same but a generator might very well output instances of smaller sizes if they e.g. have a strategy that works only for prime sizes. This has also lead to some bugs in the Algobattle Problems code where things like vertex indices were compared to the maximum size, not the actual size.

This PR clarifies this difference by renaming the size arguments to max_size, and also removing them from the methods that are called after instance validation. This makes it so that validate_instance clearly states what the intention of this argument is, and that you need to use actual instance properties for later checks rather than the maximum instance size of the fight.