### PR TITLE
Safer error messages

### DIFF
--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from traceback import format_exception
-from typing import Any, Iterable, Literal, TypeVar, Self
+from typing import Any, Iterable, Literal, LiteralString, TypeVar, Self
 
 from pydantic import BaseConfig, BaseModel as PydandticBaseModel, Extra, ValidationError as PydanticValidationError
 
@@ -188,7 +188,7 @@ def flat_intersperse(iterable: Iterable[Iterable[T]], element: T) -> Iterable[T]
 class AlgobattleBaseException(Exception):
     """Base exception class for errors used by the algobattle package."""
 
-    def __init__(self, message: str, *, detail: str | None = None) -> None:
+    def __init__(self, message: LiteralString, *, detail: str | None = None) -> None:
         """Base exception class for errors used by the algobattle package.
 
         Args:
@@ -215,7 +215,7 @@ class BuildError(AlgobattleBaseException):
 class ExecutionError(AlgobattleBaseException):
     """Indicates that the program could not be executed successfully."""
 
-    def __init__(self, message: str, *, detail: str | None = None, runtime: float) -> None:
+    def __init__(self, message: LiteralString, *, detail: str | None = None, runtime: float) -> None:
         """Indicates that the program could not be executed successfully.
 
         Args:


### PR DESCRIPTION
There is a potential attack vector where an error such as
```py
EncodingError(f"Vertex {v} is invalid")
```
can be abused by students to leak information. For example, a solver could encode the generator's instance into a single (very large) int, and then use it in a proposed solution. This would obviously raise an error, which contains this int. When viewing the logs the error would then expose the other team's instance.

To prevent this I've adopted a two tier error messaging system, each exception we raise has a plain and a detailed error message, with the intention being that the plain error contains static info about the general class of problem that occurred and the detailed containing specifics about this particular situation. The idea then is that we can display the plain error messages in public logs without exposing any information about other team's code, and people can view detailed error messages in logs from test runs on their local machine to get detailed debugging info.

Python has a nice system where you can help with stuff like this by using the `LiteralString` type which accepts any string that is statically known, so `"abc" + "def"` is accepted by type checkers, but `f"{runtime_var}"` is not. This doesn't change runtime behaviour, but makes it easier to catch potential information leaks with linters.