### PR TITLE
Clarify Problem.score

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -168,8 +168,8 @@ class FightHandler:
         if sol_result.solution is None:
             return self._saved(Fight(score=0, size=size, generator=gen_result.info, solver=sol_result.info))
 
-        score = gen_result.instance.calculate_score(
-            solution=sol_result.solution, generator_solution=gen_result.solution, size=size
+        score = gen_result.instance.score(
+            solver_solution=sol_result.solution, generator_solution=gen_result.solution, size=size
         )
         score = max(0, min(1, float(score)))
         return self._saved(Fight(score=score, size=size, generator=gen_result.info, solver=sol_result.info))

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -85,8 +85,8 @@ class Problem(Encodable, ABC):
     def score(self, solver_solution: _Solution, generator_solution: _Solution | None, size: int) -> float:
         """Calculates how well a solution solves this problem instance.
 
-        There is a default implementation if the solution is :cls:`Scored`. For it, the calculated score is the ratio of
-        the generator's solution score to the solver's solution score.
+        If the solution is :cls:`Scored` the score is the ratio of the generator's solution score to the solver's
+        solution score. Otherwise, it simply defaults to 1 since the solver generated a valid solution.
 
         Args:
             solver_solution: The solution created by the solver.
@@ -111,7 +111,7 @@ class Problem(Encodable, ABC):
             else:
                 return sol_score / gen_score
         else:
-            raise NotImplementedError
+            return 1
 
     @staticmethod
     def _is_importable(val: Any):

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -82,14 +82,14 @@ class Problem(Encodable, ABC):
         """
         return
 
-    def calculate_score(self, solution: _Solution, generator_solution: _Solution | None, size: int) -> float:
+    def score(self, solver_solution: _Solution, generator_solution: _Solution | None, size: int) -> float:
         """Calculates how well a solution solves this problem instance.
 
         There is a default implementation if the solution is :cls:`Scored`. For it, the calculated score is the ratio of
         the generator's solution score to the solver's solution score.
 
         Args:
-            solution: The solution created by the solver.
+            solver_solution: The solution created by the solver.
             generator_solution: The solution output by the generator, if any.
             size: The instance size.
 
@@ -98,11 +98,11 @@ class Problem(Encodable, ABC):
             1 that it solved the instance perfectly.
         """
         if isinstance(generator_solution, self.Solution) and isinstance(generator_solution, Scored):
-            assert isinstance(solution, Scored)
+            assert isinstance(solver_solution, Scored)
             gen_score = generator_solution.score(self, size)
             if gen_score == 0:
                 return 1
-            sol_score = solution.score(self, size)
+            sol_score = solver_solution.score(self, size)
             if sol_score == 0:
                 return 0
 

--- a/tests/testsproblem/problem.py
+++ b/tests/testsproblem/problem.py
@@ -27,5 +27,5 @@ class TestProblem(ProblemModel):
         if not self.semantics:
             raise ValidationError("")
 
-    def score(self, solution: Solution, generator_solution: Solution | None, size: int) -> float:
-        return solution.quality
+    def score(self, solver_solution: Solution, generator_solution: Solution | None, size: int) -> float:
+        return solver_solution.quality

--- a/tests/testsproblem/problem.py
+++ b/tests/testsproblem/problem.py
@@ -27,5 +27,5 @@ class TestProblem(ProblemModel):
         if not self.semantics:
             raise ValidationError("")
 
-    def calculate_score(self, solution: Solution, generator_solution: Solution | None, size: int) -> float:
+    def score(self, solution: Solution, generator_solution: Solution | None, size: int) -> float:
         return solution.quality


### PR DESCRIPTION
This just slightly renames the method and parameter of the Problem scoring function to make it a bit simpler and clearer. It also makes the default implementation return 1 so that problems like Pairsum where we aren't really scoring the solution quality and just want to check if the solver can generate a valid one are handled by default.