### PR TITLE
Add int helper types for common ranges

### DIFF
--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar, Literal, Protocol, Self, Generic, TypeAlias, T
 from pydantic import Field
 from pydantic.generics import GenericModel
 
-from algobattle.util import Encodable, EncodableModel, ValidationError
+from algobattle.util import u64, Encodable, EncodableModel, ValidationError
 
 
 _Problem: TypeAlias = Any
@@ -239,8 +239,8 @@ class DirectedGraph(ProblemModel):
 
     export: ClassVar[bool] = False
 
-    num_vertices: int = Field(ge=0, le=2**63 - 1)
-    edges: list[tuple[int, int]] = Field(ge=0, le=2**63 - 1, unique_items=True)
+    num_vertices: u64
+    edges: list[tuple[u64, u64]] = Field(unique_items=True)
 
     def validate_instance(self, size: int):
         """Validates that the graph contains at most `size` many vertices and all edges are well defined."""

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -8,9 +8,15 @@ from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from traceback import format_exception
-from typing import Any, Iterable, Literal, TypeVar, Self
+from typing import Annotated, Any, Iterable, Literal, TypeVar, Self
 
-from pydantic import BaseConfig, BaseModel as PydandticBaseModel, Extra, ValidationError as PydanticValidationError
+from pydantic import (
+    BaseConfig,
+    BaseModel as PydandticBaseModel,
+    Extra,
+    ValidationError as PydanticValidationError,
+    conint,
+)
 
 
 Role = Literal["generator", "solver"]
@@ -33,6 +39,12 @@ class BaseModel(PydandticBaseModel):
 
         extra = Extra.forbid
         underscore_attrs_are_private = False
+
+
+u64 = Annotated[conint(ge=0, le=2**64 - 1), ...]
+"""Helper type to easily define model fields that fit into a 64 bit unsigned int."""
+i64 = Annotated[conint(ge=-(2**63), le=2**63 - 1), ...]
+"""Helper type to easily define model fields that fit into a 64 bit signed int."""
 
 
 def inherit_docs(obj: T) -> T:


### PR DESCRIPTION
This adds helper types to easily define problem models with commonly used int ranges. for example, instead of the current

```py
class MyProblem(ProblemModel):
    some_numbers: list[int] = Field(ge=0, le=2 ** 64 - 1)
```

to ensure that students can safely use unsigned 64 bit ints, we can just use

```py
class MyProblem(ProblemModel):
    some_numbers: list[u64]
```