### PR TITLE
remove setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-"""Mandatory `setup.py` file needed for pip installs.
-
-Legacy install options still need a setup.py file in addition to the pyproject.toml specification.
-With future updates this file hopefully will become completely obsolete.
-"""
-
-import setuptools
-
-setuptools.setup()


### PR DESCRIPTION
setuptools no longer needs the no-op setup.py file for editable installs, we can clean the project up a little and remove it now.