### PR TITLE
Better config structure

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -9,7 +9,6 @@ from abc import abstractmethod
 from typing import (
     Any,
     ClassVar,
-    Generic,
     Protocol,
     TypeAlias,
     TypeVar,
@@ -23,7 +22,7 @@ from algobattle.docker_util import (
     ProgramUiProxy,
     Solver,
 )
-from algobattle.problem import InstanceT, Problem, SolutionT
+from algobattle.problem import AnyProblem
 from algobattle.util import Encodable, Role, inherit_docs, BaseModel
 
 
@@ -77,12 +76,12 @@ class FightUiProxy(Protocol):
 
 
 @dataclass
-class FightHandler(Generic[InstanceT, SolutionT]):
+class FightHandler:
     """Helper class to run fights of a given battle."""
 
-    _problem: Problem[InstanceT, SolutionT]
-    _generator: Generator[InstanceT, SolutionT]
-    _solver: Solver[InstanceT, SolutionT]
+    _problem: AnyProblem
+    _generator: Generator
+    _solver: Solver
     _battle: "Battle"
     _ui: FightUiProxy
     _set_cpus: str | None = None
@@ -270,9 +269,7 @@ class Battle(BaseModel):
         return cls.__name__
 
     @abstractmethod
-    async def run_battle(
-        self, fight: FightHandler[InstanceT, SolutionT], config: _BattleConfig, min_size: int, ui: BattleUiProxy
-    ) -> None:
+    async def run_battle(self, fight: FightHandler, config: _BattleConfig, min_size: int, ui: BattleUiProxy) -> None:
         """Executes one battle.
 
         Args:
@@ -308,9 +305,7 @@ class Iterated(Battle):
         reached: list[int]
         cap: int
 
-    async def run_battle(
-        self, fight: FightHandler[InstanceT, SolutionT], config: BattleConfig, min_size: int, ui: BattleUiProxy
-    ) -> None:
+    async def run_battle(self, fight: FightHandler, config: BattleConfig, min_size: int, ui: BattleUiProxy) -> None:
         """Execute an iterated battle.
 
         Incrementally tries to search for the highest n for which the solver is still able to solve instances.
@@ -382,9 +377,7 @@ class Averaged(Battle):
     class UiData(Battle.UiData):
         round: int
 
-    async def run_battle(
-        self, fight: FightHandler[InstanceT, SolutionT], config: BattleConfig, min_size: int, ui: BattleUiProxy
-    ) -> None:
+    async def run_battle(self, fight: FightHandler, config: BattleConfig, min_size: int, ui: BattleUiProxy) -> None:
         """Execute an averaged battle.
 
         This simple battle type just executes `iterations` many fights after each other at size `instance_size`.

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -4,14 +4,19 @@ This module contains the :class:`Battle` class, which speciefies how each type o
 some basic battle types, and related classed.
 """
 from dataclasses import dataclass
+from functools import wraps
 from importlib.metadata import entry_points
 from abc import abstractmethod
 from inspect import isclass
 from typing import (
     Any,
+    Awaitable,
+    Callable,
     ClassVar,
+    Concatenate,
     Hashable,
     Literal,
+    ParamSpec,
     Protocol,
     Self,
     TypeAlias,
@@ -26,11 +31,11 @@ from pydantic_core.core_schema import tagged_union_schema
 from algobattle.docker_util import (
     Generator,
     ProgramRunInfo,
-    ProgramUiProxy,
+    ProgramUi,
     Solver,
 )
 from algobattle.problem import AnyProblem
-from algobattle.util import Encodable, Role, inherit_docs, BaseModel
+from algobattle.util import Encodable, inherit_docs, BaseModel
 
 
 _BattleConfig: TypeAlias = Any
@@ -42,6 +47,8 @@ When creating your own battle type it is recommended to not use this alias and i
 the new battle type directly.
 """
 T = TypeVar("T")
+P = ParamSpec("P")
+RunFight: TypeAlias = "Callable[Concatenate[FightHandler, P], Awaitable[Fight]]"
 Type = type
 
 
@@ -64,41 +71,41 @@ class Fight(BaseModel):
     """Data about the solver's execution."""
 
 
-class FightUiProxy(Protocol):
+class FightUi(ProgramUi, Protocol):
     """Provides an interface for :class:`Fight` to update the ui."""
 
-    generator: ProgramUiProxy
-    solver: ProgramUiProxy
-
     @abstractmethod
-    def start(self, max_size: int) -> None:
+    def start_fight(self, max_size: int) -> None:
         """Informs the ui that a new fight has been started."""
 
     @abstractmethod
-    def update(self, role: Role, data: ProgramRunInfo) -> None:
-        """Updates the ui's current fight section with new data about a program."""
-
-    @abstractmethod
-    def end(self) -> None:
+    def end_fight(self) -> None:
         """Informs the ui that the fight has finished running and has been added to the battle's `.fight_results`."""
+
+
+def _save_result(func: "RunFight[P]") -> "RunFight[P]":
+    @wraps(func)
+    async def inner(self: "FightHandler", *args: P.args, **kwargs: P.kwargs) -> Fight:
+        res = await func(self, *args, **kwargs)
+        self.battle.fights.append(res)
+        self.ui.end_fight()
+        return res
+
+    return inner
 
 
 @dataclass
 class FightHandler:
     """Helper class to run fights of a given battle."""
 
-    _problem: AnyProblem
-    _generator: Generator
-    _solver: Solver
-    _battle: "Battle"
-    _ui: FightUiProxy
-    _set_cpus: str | None = None
+    problem: AnyProblem
+    generator: Generator
+    solver: Solver
+    battle: "Battle"
+    ui: FightUi
+    set_cpus: str | None
 
-    def _saved(self, fight: Fight) -> Fight:
-        self._battle.fight_results.append(fight)
-        self._ui.end()
-        return fight
-
+    @_save_result
     async def run(
         self,
         max_size: int,
@@ -141,29 +148,28 @@ class FightHandler:
         Returns:
             The resulting info about the executed fight.
         """
-        min_size = self._problem.min_size
+        min_size = self.problem.min_size
         if max_size < min_size:
             raise ValueError(
                 f"Cannot run battle at size {max_size} since it is smaller than the smallest "
-                "size the problem allows ({min_size})."
+                f"size the problem allows ({min_size})."
             )
-        ui = self._ui
-        ui.start(max_size)
-        gen_result = await self._generator.run(
+        ui = self.ui
+        ui.start_fight(max_size)
+        gen_result = await self.generator.run(
             max_size=max_size,
             timeout=timeout_generator,
             space=space_generator,
             cpus=cpus_generator,
             battle_input=generator_battle_input,
             battle_output=generator_battle_output,
-            set_cpus=self._set_cpus,
-            ui=ui.generator,
+            set_cpus=self.set_cpus,
+            ui=ui,
         )
-        ui.update(Role.generator, gen_result.info)
         if gen_result.instance is None:
-            return self._saved(Fight(score=1, max_size=max_size, generator=gen_result.info, solver=None))
+            return Fight(score=1, max_size=max_size, generator=gen_result.info, solver=None)
 
-        sol_result = await self._solver.run(
+        sol_result = await self.solver.run(
             gen_result.instance,
             max_size=max_size,
             timeout=timeout_solver,
@@ -171,32 +177,29 @@ class FightHandler:
             cpus=cpus_solver,
             battle_input=solver_battle_input,
             battle_output=solver_battle_output,
-            set_cpus=self._set_cpus,
-            ui=ui.solver,
+            set_cpus=self.set_cpus,
+            ui=ui,
         )
-        ui.update(Role.solver, sol_result.info)
         if sol_result.solution is None:
-            return self._saved(Fight(score=0, max_size=max_size, generator=gen_result.info, solver=sol_result.info))
+            return Fight(score=0, max_size=max_size, generator=gen_result.info, solver=sol_result.info)
 
-        if self._problem.with_solution:
+        if self.problem.with_solution:
             assert gen_result.solution is not None
-            score = self._problem.score(
+            score = self.problem.score(
                 gen_result.instance, solver_solution=sol_result.solution, generator_solution=gen_result.solution
             )
         else:
-            score = self._problem.score(gen_result.instance, solution=sol_result.solution)
+            score = self.problem.score(gen_result.instance, solution=sol_result.solution)
         score = max(0, min(1, float(score)))
-        return self._saved(Fight(score=score, max_size=max_size, generator=gen_result.info, solver=sol_result.info))
+        return Fight(score=score, max_size=max_size, generator=gen_result.info, solver=sol_result.info)
 
 
 # We need this to be here to prevent an import cycle between match.py and battle.py
-class BattleUiProxy(Protocol):
+class BattleUi(Protocol):
     """Provides an interface for :class:`Battle` to update the Ui."""
 
-    fight_ui: FightUiProxy
-
     @abstractmethod
-    def update_data(self, data: "Battle.UiData") -> None:
+    def update_battle_data(self, data: "Battle.UiData") -> None:
         """Passes new custom display data to the Ui.
 
         See :class:`Battle.UiData` for further details.
@@ -210,7 +213,7 @@ class Battle(BaseModel):
     they will ultimately be scored.
     """
 
-    fight_results: list[Fight] = Field(default_factory=list)
+    fights: list[Fight] = Field(default_factory=list)
     """The list of fights that have been fought in this battle."""
     run_exception: str | None = None
     """The description of an otherwise unhandeled exception that occured during the execution of :meth:`Battle.run`."""
@@ -309,7 +312,7 @@ class Battle(BaseModel):
         return cls.__name__
 
     @abstractmethod
-    async def run_battle(self, fight: FightHandler, config: _BattleConfig, min_size: int, ui: BattleUiProxy) -> None:
+    async def run_battle(self, fight: FightHandler, config: _BattleConfig, min_size: int, ui: BattleUi) -> None:
         """Executes one battle.
 
         Args:
@@ -348,7 +351,7 @@ class Iterated(Battle):
         reached: list[int]
         cap: int
 
-    async def run_battle(self, fight: FightHandler, config: Config, min_size: int, ui: BattleUiProxy) -> None:
+    async def run_battle(self, fight: FightHandler, config: Config, min_size: int, ui: BattleUi) -> None:
         """Execute an iterated battle.
 
         Incrementally tries to search for the highest n for which the solver is still able to solve instances.
@@ -367,7 +370,7 @@ class Iterated(Battle):
             cap = config.maximum_size
             current = min_size
             while alive:
-                ui.update_data(self.UiData(reached=self.results + [reached], cap=cap))
+                ui.update_battle_data(self.UiData(reached=self.results + [reached], cap=cap))
                 result = await fight.run(current)
                 score = result.score
                 if score < config.minimum_score:
@@ -395,7 +398,6 @@ class Iterated(Battle):
                         base_increment = 1
             self.results.append(reached)
 
-    @inherit_docs
     def score(self) -> float:
         """Averages the highest instance size reached in each round."""
         return 0 if len(self.results) == 0 else sum(self.results) / len(self.results)
@@ -423,7 +425,7 @@ class Averaged(Battle):
     class UiData(Battle.UiData):
         round: int
 
-    async def run_battle(self, fight: FightHandler, config: Config, min_size: int, ui: BattleUiProxy) -> None:
+    async def run_battle(self, fight: FightHandler, config: Config, min_size: int, ui: BattleUi) -> None:
         """Execute an averaged battle.
 
         This simple battle type just executes `iterations` many fights after each other at size `instance_size`.
@@ -431,16 +433,15 @@ class Averaged(Battle):
         if config.instance_size < min_size:
             raise ValueError(f"size {config.instance_size} is smaller than the smallest valid size, {min_size}.")
         for i in range(config.num_fights):
-            ui.update_data(self.UiData(round=i + 1))
+            ui.update_battle_data(self.UiData(round=i + 1))
             await fight.run(config.instance_size)
 
-    @inherit_docs
     def score(self) -> float:
         """Averages the score of each fight."""
-        if len(self.fight_results) == 0:
+        if len(self.fights) == 0:
             return 0
         else:
-            return sum(f.score for f in self.fight_results) / len(self.fight_results)
+            return sum(f.score for f in self.fights) / len(self.fights)
 
     @inherit_docs
     @staticmethod

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -83,8 +83,8 @@ def main():
             result = run(_run_with_ui, config, exec_config.problem)
         print("\n".join(CliUi.display_match(result)))
 
-        if config.match.points > 0:
-            points = result.calculate_points(config.match.points)
+        if config.execution.points > 0:
+            points = result.calculate_points(config.execution.points)
             for team, pts in points.items():
                 print(f"Team {team} gained {pts:.1f} points.")
 

--- a/algobattle/docker_util.py
+++ b/algobattle/docker_util.py
@@ -37,7 +37,6 @@ from algobattle.util import (
     RunConfigOverride,
     ValidationError,
     Role,
-    inherit_docs,
     BaseModel,
 )
 from algobattle.problem import AnyProblem, Instance, Solution
@@ -747,8 +746,7 @@ class Program(ABC):
                 solution=output_data,
             )
 
-    @inherit_docs
-    def remove(self) -> None:
+    def remove(self) -> None:  # noqa: D102
         self.image.remove()
 
     def __enter__(self):

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import tomllib
 from typing import Annotated, Self, cast, overload
 
-from pydantic import Field, model_validator
+from pydantic import Field
 from anyio import create_task_group, CapacityLimiter
 from anyio.to_thread import current_default_thread_limiter
 
@@ -17,32 +17,13 @@ from algobattle.team import BuildUi, Matchup, Team, TeamHandler, TeamInfos
 from algobattle.problem import InstanceT, Problem, SolutionT
 from algobattle.util import (
     ExceptionInfo,
+    ExecutionConfig,
     MatchConfig,
-    MatchMode,
     Role,
     RunningTimer,
     BaseModel,
     str_with_traceback,
 )
-
-
-class ExecutionConfig(BaseModel):
-    """Settings that only determine how a match is run, not its result."""
-
-    parallel_battles: int = 1
-    """Number of battles exectuted in parallel."""
-    mode: MatchMode = "testing"
-    """Mode of the match."""
-    set_cpus: str | list[str] | None = None
-    """Wich cpus to run programs on, if a list is specified each battle will use a different cpu specification in it."""
-
-    @model_validator(mode="after")
-    def val_set_cpus(self) -> Self:
-        """Validates that each battle that is being executed is assigned some cpu cores."""
-        if isinstance(self.set_cpus, list) and self.parallel_battles > len(self.set_cpus):
-            raise ValueError("Number of parallel battles exceeds the number of set_cpu specifier strings.")
-        else:
-            return self
 
 
 class BaseConfig(BaseModel):

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -1,6 +1,5 @@
 """Module defining the Problem and Solution base classes and related objects."""
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from functools import wraps
 from importlib.metadata import entry_points
 import importlib.util
@@ -200,49 +199,82 @@ def default_score(
         return max(0, min(1, solution.score(instance, Role.solver)))
 
 
-@dataclass(kw_only=True)
-class ProblemBase(Generic[InstanceT, SolutionT]):
+class Problem(Generic[InstanceT, SolutionT]):
     """The definition of a problem."""
 
-    name: str
-    """The name of the problem."""
+    @inherit_docs
+    @overload
+    def __init__(
+        self,
+        *,
+        name: str,
+        instance_cls: type[InstanceT],
+        solution_cls: type[SolutionT],
+        min_size: int = 0,
+        with_solution: Literal[True] = True,
+        export: bool = True,
+        score_function: ScoreFunctionWithSol[InstanceT, SolutionT] = default_score,
+    ) -> None:
+        ...
 
-    instance_cls: type[InstanceT]
-    """Class defining what instances of this problem look like."""
+    @inherit_docs
+    @overload
+    def __init__(
+        self,
+        *,
+        name: str,
+        instance_cls: type[InstanceT],
+        solution_cls: type[SolutionT],
+        min_size: int = 0,
+        with_solution: Literal[False],
+        export: bool = True,
+        score_function: ScoreFunctionNoSol[InstanceT, SolutionT] = default_score,
+    ) -> None:
+        ...
 
-    solution_cls: type[SolutionT]
-    """Class definitng what solutions of this problem look like."""
+    def __init__(
+        self,
+        *,
+        name: str,
+        instance_cls: type[InstanceT],
+        solution_cls: type[SolutionT],
+        min_size: int = 0,
+        with_solution: bool = True,
+        export: bool = True,
+        score_function: ScoreFunction[InstanceT, SolutionT] = default_score,
+    ) -> None:
+        """The definition of a problem.
 
-    min_size: int = 0
-    """Minimum size of valid instances of this problem."""
+        Args:
+            name: The name of the problem.
+            instance_cls: Class defining what instances of this problem look like.
+            solution_cls: Class definitng what solutions of this problem look like.
+            min_size: Minimum size of valid instances of this problem.
+            with_solution: Whether the generator should also create a solution.
+            export: Wether the class should be exported.
+                If a battle is run by specifying a module, exactly one Problem in it must have `export=True`. It will
+                then be used to run the battle.
+            score_function: Function used to score how well a solution solves a problem instance.
 
-    with_solution: bool = True
-    """Whether the generator should also create a solution."""
+                The default scoring function returns the quotient of the solver's to the generator's solution score.
 
-    export: bool = True
-    """Wether the class should be exported.
+                The score function always takes the instance as the first argument. If `with_solution` is set it then
+                gets the generated solutions at `generator_solution` and `solver_solution`. If it is not set it receives
+                the solver's solution at `solution`. It should return the calculated score, a number in [0, 1] with a
+                value of 0 indicating that the solver failed completely and 1 that it solved the instance perfectly.
+        """
+        self.name = name
+        self.instance_cls = instance_cls
+        self.solution_cls = solution_cls
+        self.min_size = min_size
+        self.with_solution = with_solution
+        self.export = export
+        self.score_function = score_function
+        if self.export and self.name not in self._installed:
+            self._installed[self.name] = self
 
-    If a battle is run by specifying a module, exactly one Problem in it must have `export=True`. It will then be used
-    to run the battle.
-    """
-
-    score_function: ScoreFunction[InstanceT, SolutionT] = default_score
-    """Function used to score how well a solution solves a problem instance.
-
-    The default scoring function uses the `Scored` protocol to compare the solver's solution to the generator's. If the
-    used solution class does not support this, it  will always return 1 and thus score all valid solutions equally.
-
-    The score function always takes the instance as the first argument. If `with_solution` is set it then gets the
-    generated solutions at `generator_solution` and `solver_solution`. If it is not set it receives the solver's
-    solution at `solution`. It should return the calculated score, a number in [0, 1] with a value of 0 indicating that
-    the solver failed completely and 1 that it solved the instance perfectly.
-    """
-
-    _installed: ClassVar[dict[str, Self]] = {}
-
-    def __post_init__(self) -> None:
-        if self.export and self.name not in ProblemBase._installed:
-            ProblemBase._installed[self.name] = self
+    __slots__ = ("name", "instance_cls", "solution_cls", "min_size", "with_solution", "export", "score_function")
+    _installed: "ClassVar[dict[str, AnyProblem]]" = {}
 
     @overload
     def score(self, instance: InstanceT, *, solution: SolutionT) -> float:
@@ -275,7 +307,7 @@ class ProblemBase(Generic[InstanceT, SolutionT]):
             return self.score_function(instance, solution=solution)
 
     @classmethod
-    def import_from_path(cls, path: Path) -> Self:
+    def import_from_path(cls, path: Path) -> "AnyProblem":
         """Try to import a Problem from a given path.
 
         The specified file will be imported using the standard python loaders. If the created module contains exactly
@@ -322,7 +354,7 @@ class ProblemBase(Generic[InstanceT, SolutionT]):
             sys.modules.pop("_problem")
 
     @classmethod
-    def all(cls) -> dict[str, Self]:
+    def all(cls) -> "dict[str, AnyProblem]":
         """Returns a dictionary mapping the names of all installed problems to their python objects.
 
         It includes all Problem objects that have been created so far and ones exposed to the algobattle module via the
@@ -342,43 +374,7 @@ class ProblemBase(Generic[InstanceT, SolutionT]):
         return cls._installed
 
 
-# Helper class to provide overloads for the __init__ so that score function type and with_solution match up
-class Problem(ProblemBase[InstanceT, SolutionT]):
-    """The definition of a problem."""
-
-    @inherit_docs
-    @overload
-    def __init__(
-        self,
-        *,
-        name: str,
-        instance_cls: type[InstanceT],
-        solution_cls: type[SolutionT],
-        min_size: int = 0,
-        with_solution: Literal[True] = True,
-        export: bool = True,
-        score_function: ScoreFunctionWithSol[InstanceT, SolutionT] = default_score,
-    ) -> None:
-        ...
-
-    @inherit_docs
-    @overload
-    def __init__(
-        self,
-        *,
-        name: str,
-        instance_cls: type[InstanceT],
-        solution_cls: type[SolutionT],
-        min_size: int = 0,
-        with_solution: Literal[False],
-        export: bool = True,
-        score_function: ScoreFunctionNoSol[InstanceT, SolutionT] = default_score,
-    ) -> None:
-        ...
-
-    @inherit_docs
-    def __init__(self, *args, **kwargs) -> None:
-        return super().__init__(*args, **kwargs)
+AnyProblem = Problem[Any, Any]
 
 
 class InstanceModel(Instance, EncodableModel, ABC):
@@ -395,7 +391,7 @@ class SolutionModel(Solution[InstanceT], EncodableModel, ABC):
     @classmethod
     def decode(cls, source: Path, max_size: int, role: Role, instance: InstanceT | None = None) -> Self:
         """Uses pydantic to create a python object from a `.json` file."""
-        context = {"max_size": max_size, "role": role}
+        context: dict[str, Any] = {"max_size": max_size, "role": role}
         if instance is not None:
             context["instance"] = instance
         return cls._decode(source, **context)

--- a/algobattle/team.py
+++ b/algobattle/team.py
@@ -2,14 +2,13 @@
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from itertools import combinations
-from pathlib import Path
-from typing import Any, Iterator, Protocol, Self, TypeAlias
+from typing import Annotated, Any, Iterator, Protocol, Self, TypeAlias
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from algobattle.docker_util import DockerConfig, Generator, Solver
 from algobattle.problem import AnyProblem
-from algobattle.util import ExceptionInfo, MatchConfig, MatchMode, Role
+from algobattle.util import ExceptionInfo, MatchConfigBase, MatchMode, RelativePath, Role
 
 
 _team_names: set[str] = set()
@@ -30,14 +29,14 @@ class BuildUi(Protocol):
 class TeamInfo(BaseModel):
     """The config parameters defining a team."""
 
-    generator: Path
-    solver: Path
+    generator: RelativePath
+    solver: RelativePath
 
     async def build(
         self,
         name: str,
         problem: AnyProblem,
-        match_config: MatchConfig,
+        match_config: MatchConfigBase,
         docker_config: DockerConfig,
         name_programs: bool,
         ui: BuildUi,
@@ -92,7 +91,7 @@ class TeamInfo(BaseModel):
         return Team(name, generator, solver)
 
 
-TeamInfos: TypeAlias = dict[str, TeamInfo]
+TeamInfos: TypeAlias = Annotated[dict[str, TeamInfo], Field(validate_default=True)]
 
 
 @dataclass
@@ -169,7 +168,7 @@ class TeamHandler:
         infos: TeamInfos,
         problem: AnyProblem,
         mode: MatchMode,
-        match_config: MatchConfig,
+        match_config: MatchConfigBase,
         docker_config: DockerConfig,
         ui: BuildUi,
     ) -> Self:

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -493,8 +493,6 @@ class MatchConfigBase(BaseModel):
     It will be parsed from the given config file and contains all settings that specify how the match is run.
     """
 
-    points: int = 100
-    """Highest number of points each team can achieve."""
     build_timeout: WithNone[TimeDeltaFloat] = 600
     """Timeout for building each docker image."""
     image_size: WithNone[ByteSizeInt] = None
@@ -514,6 +512,8 @@ class ExecutionConfig(BaseModel):
     """Mode of the match."""
     set_cpus: str | list[str] | None = None
     """Wich cpus to run programs on, if a list is specified each battle will use a different cpu specification in it."""
+    points: int = 100
+    """Highest number of points each team can achieve."""
 
     @model_validator(mode="after")
     def val_set_cpus(self) -> Self:

--- a/docs/src/config.toml
+++ b/docs/src/config.toml
@@ -1,33 +1,32 @@
-[teams]
+[teams.team_0]
+generator = "./generator"
+solver = "./solver"
 
 [match]
-battle_type = "Iterated"
-points = 100
-parallel_battles = 1
-mode = "testing"
-
-[program]
-build_timeout = 0
+problem = "./problem.py"
+build_timeout = "00:10:00"
 strict_timeouts = false
-image_size = 0
-set_cpus = ""
+image_size = false
 
-[program.generator]
+[match.generator]
 timeout = 30
 space = 0
 cpus = 1
 
-[program.solver]
+[match.solver]
 timeout = 30
 space = 0
 cpus = 1
 
-[battle.Iterated]
+[battle]
+type = "Iterated"
 rounds = 5
 maximum_size = 50_000
 exponent = 2
 minimum_score = 1
 
-[battle.Averaged]
-instance_size = 10
-num_fights = 10
+[execution]
+points = 100
+parallel_battles = 1
+set_cpus = false
+mode = "testing"

--- a/tests/configs/teams.toml
+++ b/tests/configs/teams.toml
@@ -5,3 +5,6 @@ solver = "."
 [teams."team 2"]
 generator = "."
 solver = "."
+
+[match]
+problem = "Test Problem"

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,9 +1,9 @@
 [match]
 points = 10
-battle_type = "Averaged"
 
 [program.generator]
 space = 10
 
-[battle.Averaged]
+[battle]
+type = "Averaged"
 num_fights = 1

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,7 +1,7 @@
 [match]
 points = 10
 
-[program.generator]
+[match.generator]
 space = 10
 
 [battle]

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,5 +1,4 @@
 [match]
-points = 10
 problem = "Test Problem"
 
 [match.generator]
@@ -8,3 +7,6 @@ space = 10
 [battle]
 type = "Averaged"
 num_fights = 1
+
+[execution]
+points = 10

--- a/tests/configs/test.toml
+++ b/tests/configs/test.toml
@@ -1,5 +1,6 @@
 [match]
 points = 10
+problem = "Test Problem"
 
 [match.generator]
 space = 10

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -11,7 +11,6 @@ from algobattle.docker_util import (
     ExecutionError,
     Generator,
     Image,
-    ProgramConfig,
     RunConfig,
     Solver,
 )
@@ -27,8 +26,8 @@ class ImageTests(IsolatedAsyncioTestCase):
     def setUpClass(cls) -> None:
         """Set up the path to the docker containers."""
         cls.problem_path = Path(testsproblem.__file__).parent
-        cls.build_kwargs = AdvancedBuildArgs().to_docker_args()
-        cls.run_kwargs = AdvancedBuildArgs().to_docker_args()
+        cls.build_kwargs = AdvancedBuildArgs().kwargs
+        cls.run_kwargs = AdvancedRunArgs().kwargs
 
     @classmethod
     def dockerfile(cls, name: str) -> Path:
@@ -75,9 +74,7 @@ class ImageTests(IsolatedAsyncioTestCase):
         with await Image.build(
             self.problem_path / "generator_timeout", role=Role.generator, advanced_args=self.build_kwargs, max_size=None
         ) as image, self.assertRaises(ExecutionTimeout):
-            await image.run(
-                timeout=1.0, space=None, cpus=1, set_cpus=None, run_kwargs=AdvancedRunArgs().to_docker_args()
-            )
+            await image.run(timeout=1.0, space=None, cpus=1, set_cpus=None, run_kwargs=self.run_kwargs)
 
     async def test_run_error(self):
         """Raises an error if the container doesn't run successfully."""
@@ -90,9 +87,7 @@ class ImageTests(IsolatedAsyncioTestCase):
                 max_size=None,
             ) as image,
         ):
-            await image.run(
-                timeout=10.0, space=None, cpus=1, set_cpus=None, run_kwargs=AdvancedRunArgs().to_docker_args()
-            )
+            await image.run(timeout=10.0, space=None, cpus=1, set_cpus=None, run_kwargs=self.run_kwargs)
 
 
 class ProgramTests(IsolatedAsyncioTestCase):
@@ -102,90 +97,116 @@ class ProgramTests(IsolatedAsyncioTestCase):
     def setUpClass(cls) -> None:
         """Set up the config and problem objects."""
         cls.problem_path = Path(testsproblem.__file__).parent
-        cls.config = ProgramConfig()
-        cls.config_short = ProgramConfig(generator=RunConfig(timeout=2), solver=RunConfig(timeout=2))
+        cls.config = RunConfig()
+        cls.config_short = RunConfig(timeout=2)
         cls.instance = TestInstance(semantics=True)
 
     async def test_gen_lax_timeout(self):
         """The generator times out but still outputs a valid instance."""
-        with await Generator.build(self.problem_path / "generator_timeout", TestProblem, self.config_short) as gen:
+        with await Generator.build(
+            image=self.problem_path / "generator_timeout", problem=TestProblem, config=self.config_short
+        ) as gen:
             res = await gen.run(5)
             self.assertIsNone(res.info.error)
 
     async def test_gen_strict_timeout(self):
         """The generator times out."""
-        config = self.config_short.model_copy(update={"strict_timeouts": True})
-        with await Generator.build(self.problem_path / "generator_timeout", TestProblem, config) as gen:
+        with await Generator.build(
+            image=self.problem_path / "generator_timeout",
+            problem=TestProblem,
+            config=self.config_short,
+            strict_timeouts=True,
+        ) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionTimeout")
 
     async def test_gen_exec_err(self):
         """The generator doesn't execute properly."""
-        with await Generator.build(self.problem_path / "generator_execution_error", TestProblem, self.config) as gen:
+        with await Generator.build(
+            image=self.problem_path / "generator_execution_error", problem=TestProblem, config=self.config
+        ) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionError")
 
     async def test_gen_syn_err(self):
         """The generator outputs a syntactically incorrect solution."""
-        with await Generator.build(self.problem_path / "generator_syntax_error", TestProblem, self.config) as gen:
+        with await Generator.build(
+            image=self.problem_path / "generator_syntax_error", problem=TestProblem, config=self.config
+        ) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_gen_sem_err(self):
         """The generator outputs a semantically incorrect solution."""
-        with await Generator.build(self.problem_path / "generator_semantics_error", TestProblem, self.config) as gen:
+        with await Generator.build(
+            image=self.problem_path / "generator_semantics_error", problem=TestProblem, config=self.config
+        ) as gen:
             res = await gen.run(5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ValidationError")
 
     async def test_gen_succ(self):
         """The generator returns the fixed instance."""
-        with await Generator.build(self.problem_path / "generator", TestProblem, self.config) as gen:
+        with await Generator.build(
+            image=self.problem_path / "generator", problem=TestProblem, config=self.config
+        ) as gen:
             res = await gen.run(5)
             correct = TestInstance(semantics=True)
             self.assertEqual(res.instance, correct)
 
     async def test_sol_strict_timeout(self):
         """The solver times out."""
-        config = self.config.model_copy(update={"strict_timeouts": True})
-        with await Solver.build(self.problem_path / "solver_timeout", TestProblem, config) as sol:
+        with await Solver.build(
+            image=self.problem_path / "solver_timeout",
+            problem=TestProblem,
+            config=self.config_short,
+            strict_timeouts=True,
+        ) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionTimeout")
 
     async def test_sol_lax_timeout(self):
         """The solver times out but still outputs a correct solution."""
-        with await Solver.build(self.problem_path / "solver_timeout", TestProblem, self.config_short) as sol:
+        with await Solver.build(
+            image=self.problem_path / "solver_timeout", problem=TestProblem, config=self.config_short
+        ) as sol:
             res = await sol.run(self.instance, 5)
             self.assertIsNone(res.info.error)
 
     async def test_sol_exec_err(self):
         """The solver doesn't execute properly."""
-        with await Solver.build(self.problem_path / "solver_execution_error", TestProblem, self.config) as sol:
+        with await Solver.build(
+            image=self.problem_path / "solver_execution_error", problem=TestProblem, config=self.config
+        ) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ExecutionError")
 
     async def test_sol_syn_err(self):
         """The solver outputs a syntactically incorrect solution."""
-        with await Solver.build(self.problem_path / "solver_syntax_error", TestProblem, self.config) as sol:
+        with await Solver.build(
+            image=self.problem_path / "solver_syntax_error", problem=TestProblem, config=self.config
+        ) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "EncodingError")
 
     async def test_sol_sem_err(self):
         """The solver outputs a semantically incorrect solution."""
-        with await Solver.build(self.problem_path / "solver_semantics_error", TestProblem, self.config) as sol:
+        with await Solver.build(
+            image=self.problem_path / "solver_semantics_error", problem=TestProblem, config=self.config
+        ) as sol:
             res = await sol.run(self.instance, 5)
             assert res.info.error is not None
             self.assertEqual(res.info.error.type, "ValidationError")
 
     async def test_sol_succ(self):
         """The solver outputs a solution with a low quality."""
-        with await Solver.build(self.problem_path / "solver", TestProblem, self.config) as sol:
+        with await Solver.build(image=self.problem_path / "solver", problem=TestProblem, config=self.config) as sol:
             res = await sol.run(self.instance, 5)
             correct = TestSolution(semantics=True, quality=True)
             self.assertEqual(res.solution, correct)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -172,19 +172,28 @@ class Execution(IsolatedAsyncioTestCase):
     async def test_basic(self):
         self.config.teams = {"team_0": TeamInfo(generator=self.generator, solver=self.solver)}
         self.config.match.battle_type = "Iterated"
-        await Match.run(self.config, TestProblem)
+        res = await Match.run(self.config, TestProblem)
+        for res_dict in res.results.values():
+            for result in res_dict.values():
+                self.assertIsNone(result.run_exception)
 
     async def test_multi_team(self):
         team0 = TeamInfo(generator=self.generator, solver=self.solver)
         team1 = TeamInfo(generator=self.generator, solver=self.solver)
         self.config.teams = {"team_0": team0, "team_1": team1}
         self.config.match.battle_type = "Iterated"
-        await Match.run(self.config, TestProblem)
+        res = await Match.run(self.config, TestProblem)
+        for res_dict in res.results.values():
+            for result in res_dict.values():
+                self.assertIsNone(result.run_exception)
 
     async def test_averaged(self):
         self.config.teams = {"team_0": TeamInfo(generator=self.generator, solver=self.solver)}
         self.config.match.battle_type = "Averaged"
-        await Match.run(self.config, TestProblem)
+        res = await Match.run(self.config, TestProblem)
+        for res_dict in res.results.values():
+            for result in res_dict.values():
+                self.assertIsNone(result.run_exception)
 
 
 class Parsing(TestCase):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -11,6 +11,7 @@ from algobattle.battle import Fight, Iterated, Averaged
 from algobattle.match import BaseConfig, Match, MatchConfig
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo
 from algobattle.docker_util import ProgramRunInfo, RunConfig
+from algobattle.util import ExecutionConfig
 from .testsproblem.problem import TestProblem
 
 
@@ -217,11 +218,11 @@ class Parsing(TestCase):
                     "team_0": TeamInfo(generator=self.configs_path / "generator", solver=self.configs_path / "solver")
                 },
                 match=MatchConfig(
-                    points=10,
                     generator=RunConfig(space=ByteSize(10)),
                     problem="Test Problem",
                 ),
                 battle=Averaged.Config(num_fights=1),
+                execution=ExecutionConfig(points=10),
             ),
         )
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -157,11 +157,11 @@ class Execution(IsolatedAsyncioTestCase):
         cls.problem = TestProblem
         run_params = RunConfig(timeout=2)
         cls.config_iter = BaseConfig(
-            match=MatchConfig(generator=run_params, solver=run_params),
+            match=MatchConfig(generator=run_params, solver=run_params, problem="Test Problem"),
             battle=Iterated.Config(maximum_size=10, rounds=2),
         )
         cls.config_avg = BaseConfig(
-            match=MatchConfig(generator=run_params, solver=run_params),
+            match=MatchConfig(generator=run_params, solver=run_params, problem="Test Problem"),
             battle=Averaged.Config(instance_size=5, num_fights=3),
         )
         cls.generator = problem_path / "generator"

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -10,7 +10,7 @@ from algobattle.cli import parse_cli_args
 from algobattle.battle import Fight, Iterated, Averaged
 from algobattle.match import BaseConfig, Match, MatchConfig
 from algobattle.team import Team, Matchup, TeamHandler, TeamInfo
-from algobattle.docker_util import ProgramConfig, ProgramRunInfo, RunConfig
+from algobattle.docker_util import ProgramRunInfo, RunConfig
 from .testsproblem.problem import TestProblem
 
 
@@ -156,11 +156,11 @@ class Execution(IsolatedAsyncioTestCase):
         cls.problem = TestProblem
         run_params = RunConfig(timeout=2)
         cls.config_iter = BaseConfig(
-            program=ProgramConfig(generator=run_params, solver=run_params),
+            match=MatchConfig(generator=run_params, solver=run_params),
             battle=Iterated.Config(maximum_size=10, rounds=2),
         )
         cls.config_avg = BaseConfig(
-            program=ProgramConfig(generator=run_params, solver=run_params),
+            match=MatchConfig(generator=run_params, solver=run_params),
             battle=Averaged.Config(instance_size=5, num_fights=3),
         )
         cls.generator = problem_path / "generator"
@@ -216,8 +216,8 @@ class Parsing(TestCase):
                 teams=self.teams,
                 match=MatchConfig(
                     points=10,
+                    generator=RunConfig(space=ByteSize(10)),
                 ),
-                program=ProgramConfig(generator=RunConfig(space=ByteSize(10))),
                 battle=Averaged.Config(num_fights=1),
             ),
         )

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -12,7 +12,7 @@ from algobattle.docker_util import ProgramConfig, ProgramRunInfo, RunParameters
 from .testsproblem.problem import TestProblem
 
 
-class TestTeam(Team[Any, Any]):
+class TestTeam(Team):
     """Team that doesn't rely on actual docker images."""
 
     def __init__(self, team_name: str) -> None:
@@ -48,7 +48,7 @@ class Matchtests(TestCase):
         cls.team1 = TestTeam("1")
         cls.matchup0 = Matchup(cls.team0, cls.team1)
         cls.matchup1 = Matchup(cls.team1, cls.team0)
-        cls.team_dict = {
+        cls.team_dict: dict[str, Any] = {
             "active_teams": [cls.team0.name, cls.team1.name],
             "excluded_teams": {},
         }

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -159,20 +159,20 @@ class Execution(IsolatedAsyncioTestCase):
         problem_path = Path(__file__).parent / "testsproblem"
         cls.problem = TestProblem
         run_params = RunParameters(timeout=2)
-        cls.config = BaseConfig(
+        cls.config_iter = BaseConfig(
             program=ProgramConfig(generator=run_params, solver=run_params),
-            battle={
-                "Iterated": Iterated.BattleConfig(maximum_size=10, rounds=2),
-                "Averaged": Averaged.BattleConfig(instance_size=5, num_fights=3),
-            },
+            battle=Iterated.Config(maximum_size=10, rounds=2),
+        )
+        cls.config_avg = BaseConfig(
+            program=ProgramConfig(generator=run_params, solver=run_params),
+            battle=Averaged.Config(instance_size=5, num_fights=3),
         )
         cls.generator = problem_path / "generator"
         cls.solver = problem_path / "solver"
 
     async def test_basic(self):
-        self.config.teams = {"team_0": TeamInfo(generator=self.generator, solver=self.solver)}
-        self.config.match.battle_type = "Iterated"
-        res = await Match.run(self.config, TestProblem)
+        self.config_iter.teams = {"team_0": TeamInfo(generator=self.generator, solver=self.solver)}
+        res = await Match.run(self.config_iter, TestProblem)
         for res_dict in res.results.values():
             for result in res_dict.values():
                 self.assertIsNone(result.run_exception)
@@ -180,17 +180,15 @@ class Execution(IsolatedAsyncioTestCase):
     async def test_multi_team(self):
         team0 = TeamInfo(generator=self.generator, solver=self.solver)
         team1 = TeamInfo(generator=self.generator, solver=self.solver)
-        self.config.teams = {"team_0": team0, "team_1": team1}
-        self.config.match.battle_type = "Iterated"
-        res = await Match.run(self.config, TestProblem)
+        self.config_iter.teams = {"team_0": team0, "team_1": team1}
+        res = await Match.run(self.config_iter, TestProblem)
         for res_dict in res.results.values():
             for result in res_dict.values():
                 self.assertIsNone(result.run_exception)
 
     async def test_averaged(self):
-        self.config.teams = {"team_0": TeamInfo(generator=self.generator, solver=self.solver)}
-        self.config.match.battle_type = "Averaged"
-        res = await Match.run(self.config, TestProblem)
+        self.config_avg.teams = {"team_0": TeamInfo(generator=self.generator, solver=self.solver)}
+        res = await Match.run(self.config_avg, TestProblem)
         for res_dict in res.results.values():
             for result in res_dict.values():
                 self.assertIsNone(result.run_exception)
@@ -222,12 +220,9 @@ class Parsing(TestCase):
                 teams=self.teams,
                 match=MatchConfig(
                     points=10,
-                    battle_type="Averaged",
                 ),
                 program=ProgramConfig(generator=RunParameters(space=10)),
-                battle={
-                    "Averaged": Averaged.BattleConfig(num_fights=1),
-                },
+                battle=Averaged.Config(num_fights=1),
             ),
         )
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,7 @@ import random
 from pathlib import Path
 
 from algobattle.match import BaseConfig
-from algobattle.problem import Problem
+from algobattle.problem import MatchConfig, Problem
 from algobattle.battle import Battle, Iterated, Averaged
 from . import testsproblem
 
@@ -15,7 +15,7 @@ class Utiltests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Set up a problem, default config, fight handler and get a file name not existing on the file system."""
-        cls.config = BaseConfig()
+        cls.config = BaseConfig(match=MatchConfig(problem="Test Problem"))
         cls.problem_path = Path(testsproblem.__file__).parent / "problem.py"
         cls.rand_file_name = str(random.randint(0, 2**80))
         while Path(cls.rand_file_name).exists():

--- a/tests/testsproblem/problem.py
+++ b/tests/testsproblem/problem.py
@@ -35,7 +35,7 @@ def score(instance: TestInstance, solution: TestSolution) -> float:
 
 
 TestProblem = Problem(
-    name="Tests",
+    name="Test Problem",
     instance_cls=TestInstance,
     solution_cls=TestSolution,
     with_solution=False,


### PR DESCRIPTION
Previously the structure of config files was determined by where in the code we use each setting. This PR restructures it so that it instead is based on how they fit together conceptually. That is, the `battle` and `match` tables contain settings that specify what the match actually is like and what the students need to do, while all settings that only affect how the match is run are under `execution`. This means that students can safely play around with those settings to get nicer dev environments without having to worry that their code won't work in the actual tournament matches.