### PR TITLE
Simple, safe float comparisons

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -34,7 +34,7 @@ from pydantic import (
     ValidatorFunctionWrapHandler,
 )
 from pydantic_core import CoreSchema
-from pydantic_core.core_schema import tagged_union_schema, general_wrap_validator_function
+from pydantic_core.core_schema import tagged_union_schema, with_info_wrap_validator_function
 
 from algobattle.program import (
     Generator,
@@ -295,7 +295,7 @@ class Battle(BaseModel):
                             f"The specified battle type '{passed}' is not installed. Installed types are: {installed}"
                         )
 
-            return general_wrap_validator_function(check_installed, subclass_schema)
+            return with_info_wrap_validator_function(check_installed, subclass_schema)
 
     class FallbackConfig(Config):
         """Fallback config object to parse into if the proper battle typ isn't installed and we're ignoring installs."""

--- a/algobattle/types.py
+++ b/algobattle/types.py
@@ -500,7 +500,7 @@ class LaxComp:
 
     !!! example "Usage"
         ```py
-            LaxComp(some_val ** 2) <= comparison_val
+            LaxComp(some_val ** 2, role) <= comparison_val
         ```
     """
 
@@ -522,14 +522,8 @@ class LaxComp:
         else:
             return NotImplemented
 
-    def __lt__(self, other: float, /) -> bool:
-        return self.value < other
-
     def __le__(self, other: float, /) -> bool:
         return self.value <= other or self == other
-
-    def __gt__(self, other: float, /) -> bool:
-        return self.value > other
 
     def __ge__(self, other: float, /) -> bool:
         return self.value >= other or self == other

--- a/algobattle/types.py
+++ b/algobattle/types.py
@@ -7,6 +7,7 @@ from typing import (
     ClassVar,
     Collection,
     Iterator,
+    Literal,
     TypeVar,
     Generic,
     TypedDict,
@@ -70,6 +71,7 @@ __all__ = (
     "VertexWeights",
     "AlgobattleContext",
     "LaxComp",
+    "lax_comp",
 )
 
 
@@ -527,3 +529,25 @@ class LaxComp:
 
     def __ge__(self, other: float, /) -> bool:
         return self.value >= other or self == other
+
+
+def lax_comp(value: float, cmp: Literal["<=", "==", ">="], other: float, role: Role) -> bool:
+    """Helper function to explicitly use the `LaxComp` comparison mechanism.
+
+    Args:
+        value: First value to compare.
+        cmp: Comparison to perform, one of "<=", "==", or ">=".
+        other: Other value to compare.
+        role: Role of the program the values are being validated for.
+
+    Returns:
+        Result of the comparison.
+    """
+    val = LaxComp(value, role)
+    match cmp:
+        case "<=":
+            return val <= other
+        case "==":
+            return val == other
+        case ">=":
+            return val >= other

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -21,13 +21,12 @@ from annotated_types import GroupedMetadata
 from pydantic import (
     ConfigDict,
     BaseModel as PydandticBaseModel,
-    Extra,
     GetCoreSchemaHandler,
     ValidationError as PydanticValidationError,
     ValidationInfo,
 )
 from pydantic_core import CoreSchema
-from pydantic_core.core_schema import general_after_validator_function
+from pydantic_core.core_schema import with_info_after_validator_function
 
 
 class Role(StrEnum):
@@ -47,7 +46,7 @@ ModelReference = ModelType | Literal["self"]
 class BaseModel(PydandticBaseModel):
     """Base class for all pydantic models."""
 
-    model_config = ConfigDict(extra=Extra.forbid, from_attributes=True)
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
 
 
 class InstanceSolutionModel(BaseModel):
@@ -168,7 +167,7 @@ class AttributeReferenceValidator:
                     return value
                 return func(value, attribute_val)
 
-        return general_after_validator_function(wrapper, schema=schema)
+        return with_info_after_validator_function(wrapper, schema=schema)
 
     def needs_self(self, model_type: ModelType) -> bool:
         """Checks if the validator needs a reference to the current model in order to work fully."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "docker~=6.1.3",
-    "pydantic~=2.3.0",
+    "pydantic~=2.4.0",
     "anyio~=4.0.0",
     "typer[all]~=0.9.0",
     "typing-extensions~=4.8.0",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -221,74 +221,110 @@ class LaxCompTests(TestCase):
     def test_greater_equal_greater(self) -> None:
         self.assertGreaterEqual(LaxComp(1, Role.generator), 0)
         self.assertGreaterEqual(LaxComp(1, Role.solver), 0)
+        self.assertGreaterEqual(1, LaxComp(0, Role.generator))
+        self.assertGreaterEqual(1, LaxComp(0, Role.solver))
 
     def test_greater_equal_strict(self) -> None:
         self.assertGreaterEqual(LaxComp(0, Role.generator), 0)
         self.assertGreaterEqual(LaxComp(0, Role.solver), 0)
+        self.assertGreaterEqual(0, LaxComp(0, Role.generator))
+        self.assertGreaterEqual(0, LaxComp(0, Role.solver))
 
     def test_greater_equal_small(self) -> None:
         self.assertGreaterEqual(LaxComp(0, Role.generator), 0.5)
         self.assertGreaterEqual(LaxComp(0, Role.solver), 0.5)
+        self.assertGreaterEqual(0, LaxComp(0.5, Role.generator))
+        self.assertGreaterEqual(0, LaxComp(0.5, Role.solver))
 
     def test_greater_equal_medium(self) -> None:
         self.assertNotGreaterEqual(LaxComp(0, Role.generator), 1.5)
         self.assertGreaterEqual(LaxComp(0, Role.solver), 1.5)
+        self.assertNotGreaterEqual(0, LaxComp(1.5, Role.generator))
+        self.assertGreaterEqual(0, LaxComp(1.5, Role.solver))
 
     def test_greater_equal_big(self) -> None:
         self.assertNotGreaterEqual(LaxComp(0, Role.generator), 2.5)
         self.assertNotGreaterEqual(LaxComp(0, Role.solver), 2.5)
+        self.assertNotGreaterEqual(0, LaxComp(2.5, Role.generator))
+        self.assertNotGreaterEqual(0, LaxComp(2.5, Role.solver))
 
     def test_greater_equal_rel_strict(self) -> None:
         self.assertGreaterEqual(LaxComp(100, Role.generator), 100)
         self.assertGreaterEqual(LaxComp(100, Role.solver), 100)
+        self.assertGreaterEqual(100, LaxComp(100, Role.generator))
+        self.assertGreaterEqual(100, LaxComp(100, Role.solver))
 
     def test_greater_equal_rel_small(self) -> None:
         self.assertGreaterEqual(LaxComp(100, Role.generator), 110)
         self.assertGreaterEqual(LaxComp(100, Role.solver), 110)
+        self.assertGreaterEqual(100, LaxComp(110, Role.generator))
+        self.assertGreaterEqual(100, LaxComp(110, Role.solver))
 
     def test_greater_equal_rel_medium(self) -> None:
         self.assertNotGreaterEqual(LaxComp(100, Role.generator), 130)
         self.assertGreaterEqual(LaxComp(100, Role.solver), 130)
+        self.assertNotGreaterEqual(100, LaxComp(130, Role.generator))
+        self.assertGreaterEqual(100, LaxComp(130, Role.solver))
 
     def test_greater_equal_rel_big(self) -> None:
         self.assertNotGreaterEqual(LaxComp(100, Role.generator), 160)
         self.assertNotGreaterEqual(LaxComp(100, Role.solver), 160)
+        self.assertNotGreaterEqual(100, LaxComp(160, Role.generator))
+        self.assertNotGreaterEqual(100, LaxComp(160, Role.solver))
 
     def test_less_equal_less(self) -> None:
         self.assertLessEqual(LaxComp(0, Role.generator), 1)
         self.assertLessEqual(LaxComp(0, Role.solver), 1)
+        self.assertLessEqual(0, LaxComp(1, Role.generator))
+        self.assertLessEqual(0, LaxComp(1, Role.solver))
 
     def test_less_equal_strict(self) -> None:
         self.assertLessEqual(LaxComp(0, Role.generator), 0)
         self.assertLessEqual(LaxComp(0, Role.solver), 0)
+        self.assertLessEqual(0, LaxComp(0, Role.generator))
+        self.assertLessEqual(0, LaxComp(0, Role.solver))
 
     def test_less_equal_small(self) -> None:
         self.assertLessEqual(LaxComp(0.5, Role.generator), 0)
         self.assertLessEqual(LaxComp(0.5, Role.solver), 0)
+        self.assertLessEqual(0.5, LaxComp(0, Role.generator))
+        self.assertLessEqual(0.5, LaxComp(0, Role.solver))
 
     def test_less_equal_medium(self) -> None:
         self.assertNotLessEqual(LaxComp(1.5, Role.generator), 0)
         self.assertLessEqual(LaxComp(1.5, Role.solver), 0)
+        self.assertNotLessEqual(1.5, LaxComp(0, Role.generator))
+        self.assertLessEqual(1.5, LaxComp(0, Role.solver))
 
     def test_less_equal_big(self) -> None:
         self.assertNotLessEqual(LaxComp(2.5, Role.generator), 0)
         self.assertNotLessEqual(LaxComp(2.5, Role.solver), 0)
+        self.assertNotLessEqual(2.5, LaxComp(0, Role.generator))
+        self.assertNotLessEqual(2.5, LaxComp(0, Role.solver))
 
     def test_less_equal_rel_strict(self) -> None:
         self.assertLessEqual(LaxComp(100, Role.generator), 100)
         self.assertLessEqual(LaxComp(100, Role.solver), 100)
+        self.assertLessEqual(100, LaxComp(100, Role.generator))
+        self.assertLessEqual(100, LaxComp(100, Role.solver))
 
     def test_less_equal_rel_small(self) -> None:
         self.assertLessEqual(LaxComp(110, Role.generator), 100)
         self.assertLessEqual(LaxComp(110, Role.solver), 100)
+        self.assertLessEqual(110, LaxComp(100, Role.generator))
+        self.assertLessEqual(110, LaxComp(100, Role.solver))
 
     def test_less_equal_rel_medium(self) -> None:
         self.assertNotLessEqual(LaxComp(130, Role.generator), 100)
         self.assertLessEqual(LaxComp(130, Role.solver), 100)
+        self.assertNotLessEqual(130, LaxComp(100, Role.generator))
+        self.assertLessEqual(130, LaxComp(100, Role.solver))
 
     def test_less_equal_rel_big(self) -> None:
         self.assertNotLessEqual(LaxComp(160, Role.generator), 100)
         self.assertNotLessEqual(LaxComp(160, Role.solver), 100)
+        self.assertNotLessEqual(160, LaxComp(100, Role.generator))
+        self.assertNotLessEqual(160, LaxComp(100, Role.solver))
 
 
 if __name__ == "__main__":

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,12 +1,13 @@
 """Tests for pydantic parsing types."""
-from typing import Annotated
+from typing import Annotated, Any
 from unittest import TestCase, main
+from unittest.util import safe_repr
 
 from pydantic import ValidationError
 
 from algobattle.problem import InstanceModel
-from algobattle.util import AttributeReference, SelfRef
-from algobattle.types import Ge, Interval, SizeIndex, UniqueItems
+from algobattle.util import AttributeReference, Role, SelfRef
+from algobattle.types import Ge, Interval, LaxComp, SizeIndex, UniqueItems
 
 
 class ModelCreationTests(TestCase):
@@ -165,6 +166,129 @@ class UniqueItemsTest(TestCase):
     def test_schema(self):
         schema = self.TestModel.model_json_schema()
         self.assertIn("uniqueItems", schema["properties"]["array"])
+
+
+class LaxCompTests(TestCase):
+    """Tests for the LaxComp helper."""
+
+    def assertNotGreaterEqual(self, a: Any, b: Any, msg: str | None = None) -> None:
+        if msg is None:
+            msg = f"{safe_repr(a)} greater than or equal to {safe_repr(b)}"
+        self.assertFalse(a >= b, msg)
+
+    def assertNotLessEqual(self, a: Any, b: Any, msg: str | None = None) -> None:
+        if msg is None:
+            msg = f"{safe_repr(a)} less than or equal to {safe_repr(b)}"
+        self.assertFalse(a <= b, msg)
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        LaxComp.absolute_epsilon = 1
+        LaxComp.relative_epsilon = 0.1
+
+    def test_equal_strict(self) -> None:
+        self.assertEqual(LaxComp(0, Role.generator), 0)
+        self.assertEqual(LaxComp(0, Role.solver), 0)
+
+    def test_equal_small(self) -> None:
+        self.assertEqual(LaxComp(0, Role.generator), 0.5)
+        self.assertEqual(LaxComp(0, Role.solver), 0.5)
+
+    def test_equal_medium(self) -> None:
+        self.assertNotEqual(LaxComp(0, Role.generator), 1.5)
+        self.assertEqual(LaxComp(0, Role.solver), 1.5)
+
+    def test_equal_big(self) -> None:
+        self.assertNotEqual(LaxComp(0, Role.generator), 2.5)
+        self.assertNotEqual(LaxComp(0, Role.solver), 2.5)
+
+    def test_equal_rel_strict(self) -> None:
+        self.assertEqual(LaxComp(100, Role.generator), 100)
+        self.assertEqual(LaxComp(100, Role.solver), 100)
+
+    def test_equal_rel_small(self) -> None:
+        self.assertEqual(LaxComp(100, Role.generator), 110)
+        self.assertEqual(LaxComp(100, Role.solver), 110)
+
+    def test_equal_rel_medium(self) -> None:
+        self.assertNotEqual(LaxComp(100, Role.generator), 130)
+        self.assertEqual(LaxComp(100, Role.solver), 130)
+
+    def test_equal_rel_big(self) -> None:
+        self.assertNotEqual(LaxComp(100, Role.generator), 160)
+        self.assertNotEqual(LaxComp(100, Role.solver), 160)
+
+    def test_greater_equal_greater(self) -> None:
+        self.assertGreaterEqual(LaxComp(1, Role.generator), 0)
+        self.assertGreaterEqual(LaxComp(1, Role.solver), 0)
+
+    def test_greater_equal_strict(self) -> None:
+        self.assertGreaterEqual(LaxComp(0, Role.generator), 0)
+        self.assertGreaterEqual(LaxComp(0, Role.solver), 0)
+
+    def test_greater_equal_small(self) -> None:
+        self.assertGreaterEqual(LaxComp(0, Role.generator), 0.5)
+        self.assertGreaterEqual(LaxComp(0, Role.solver), 0.5)
+
+    def test_greater_equal_medium(self) -> None:
+        self.assertNotGreaterEqual(LaxComp(0, Role.generator), 1.5)
+        self.assertGreaterEqual(LaxComp(0, Role.solver), 1.5)
+
+    def test_greater_equal_big(self) -> None:
+        self.assertNotGreaterEqual(LaxComp(0, Role.generator), 2.5)
+        self.assertNotGreaterEqual(LaxComp(0, Role.solver), 2.5)
+
+    def test_greater_equal_rel_strict(self) -> None:
+        self.assertGreaterEqual(LaxComp(100, Role.generator), 100)
+        self.assertGreaterEqual(LaxComp(100, Role.solver), 100)
+
+    def test_greater_equal_rel_small(self) -> None:
+        self.assertGreaterEqual(LaxComp(100, Role.generator), 110)
+        self.assertGreaterEqual(LaxComp(100, Role.solver), 110)
+
+    def test_greater_equal_rel_medium(self) -> None:
+        self.assertNotGreaterEqual(LaxComp(100, Role.generator), 130)
+        self.assertGreaterEqual(LaxComp(100, Role.solver), 130)
+
+    def test_greater_equal_rel_big(self) -> None:
+        self.assertNotGreaterEqual(LaxComp(100, Role.generator), 160)
+        self.assertNotGreaterEqual(LaxComp(100, Role.solver), 160)
+
+    def test_less_equal_less(self) -> None:
+        self.assertLessEqual(LaxComp(0, Role.generator), 1)
+        self.assertLessEqual(LaxComp(0, Role.solver), 1)
+
+    def test_less_equal_strict(self) -> None:
+        self.assertLessEqual(LaxComp(0, Role.generator), 0)
+        self.assertLessEqual(LaxComp(0, Role.solver), 0)
+
+    def test_less_equal_small(self) -> None:
+        self.assertLessEqual(LaxComp(0.5, Role.generator), 0)
+        self.assertLessEqual(LaxComp(0.5, Role.solver), 0)
+
+    def test_less_equal_medium(self) -> None:
+        self.assertNotLessEqual(LaxComp(1.5, Role.generator), 0)
+        self.assertLessEqual(LaxComp(1.5, Role.solver), 0)
+
+    def test_less_equal_big(self) -> None:
+        self.assertNotLessEqual(LaxComp(2.5, Role.generator), 0)
+        self.assertNotLessEqual(LaxComp(2.5, Role.solver), 0)
+
+    def test_less_equal_rel_strict(self) -> None:
+        self.assertLessEqual(LaxComp(100, Role.generator), 100)
+        self.assertLessEqual(LaxComp(100, Role.solver), 100)
+
+    def test_less_equal_rel_small(self) -> None:
+        self.assertLessEqual(LaxComp(110, Role.generator), 100)
+        self.assertLessEqual(LaxComp(110, Role.solver), 100)
+
+    def test_less_equal_rel_medium(self) -> None:
+        self.assertNotLessEqual(LaxComp(130, Role.generator), 100)
+        self.assertLessEqual(LaxComp(130, Role.solver), 100)
+
+    def test_less_equal_rel_big(self) -> None:
+        self.assertNotLessEqual(LaxComp(160, Role.generator), 100)
+        self.assertNotLessEqual(LaxComp(160, Role.solver), 100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds an easy way to perform safe float comparisons, to fix the problems we mentioned in the meeting last week. I think the way this works is best illustrated with an example:

Let's say the problem instances contain a set of points and the solution contains a circle of some radius that should cover as many of these points as possible. The issue we now run into when naively comparing
```py
distance(center, point) <= size
```
is that the instance points might be placed in such a way that this calculated distance is bigger than size because of float rounding errors. This can be solved by instead comparing
```py
distance(center, point) <= size + epsilon
```

But this will now run into issues if the generating team intentionally places points in such a way that the rounding error occur at `size + epsilon` rather than just `size`. Another problem case is when the floats involved are being computed with big intermediate values, then the rounding errors might be bigger than the constant `epsilon`.

This PR lets you easily sidestep both issues by just comparing like this:
```py
distance(center, point) <= LaxComp(size, role)
```
or alternatively
```py
lax_comp(distance(center, point), "<=", size, role)
```
depending on your syntax preference. This will automatically perform the comparison including an epsilon that adjusts to the total size of the involved values and doubles this fudge factor for the solving team.