### PR TITLE
Add Ellipsis type annotation

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -9,6 +9,7 @@ from importlib.metadata import entry_points
 from abc import abstractmethod
 from inspect import isclass
 from itertools import count
+from types import EllipsisType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -118,12 +119,12 @@ class FightHandler:
         self,
         max_size: int,
         *,
-        timeout_generator: float | None = ...,
-        space_generator: int | None = ...,
-        cpus_generator: int = ...,
-        timeout_solver: float | None = ...,
-        space_solver: int | None = ...,
-        cpus_solver: int = ...,
+        timeout_generator: float | None | EllipsisType = ...,
+        space_generator: int | None | EllipsisType = ...,
+        cpus_generator: int | EllipsisType = ...,
+        timeout_solver: float | None | EllipsisType = ...,
+        space_solver: int | None | EllipsisType = ...,
+        cpus_solver: int | EllipsisType = ...,
         generator_battle_input: Encodable | None = None,
         solver_battle_input: Encodable | None = None,
         generator_battle_output: type[Encodable] | None = None,

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -1,6 +1,7 @@
 """Tests for the Battle types."""
 from enum import Enum
 from itertools import chain, cycle
+from types import EllipsisType
 from typing import Iterable, TypeVar
 from unittest import IsolatedAsyncioTestCase, main
 
@@ -51,12 +52,12 @@ class TestHandler(FightHandler):
         self,
         max_size: int,
         *,
-        timeout_generator: float | None = ...,
-        space_generator: int | None = ...,
-        cpus_generator: int = ...,
-        timeout_solver: float | None = ...,
-        space_solver: int | None = ...,
-        cpus_solver: int = ...,
+        timeout_generator: float | None | EllipsisType = ...,
+        space_generator: int | None | EllipsisType = ...,
+        cpus_generator: int | EllipsisType = ...,
+        timeout_solver: float | None | EllipsisType = ...,
+        space_solver: int | None | EllipsisType = ...,
+        cpus_solver: int | EllipsisType = ...,
         generator_battle_input: Encodable | None = None,
         solver_battle_input: Encodable | None = None,
         generator_battle_output: type[Encodable] | None = None,
@@ -95,12 +96,12 @@ class ConstantHandler(FightHandler):
         self,
         max_size: int,
         *,
-        timeout_generator: float | None = ...,
-        space_generator: int | None = ...,
-        cpus_generator: int = ...,
-        timeout_solver: float | None = ...,
-        space_solver: int | None = ...,
-        cpus_solver: int = ...,
+        timeout_generator: float | None | EllipsisType = ...,
+        space_generator: int | None | EllipsisType = ...,
+        cpus_generator: int | EllipsisType = ...,
+        timeout_solver: float | None | EllipsisType = ...,
+        space_solver: int | None | EllipsisType = ...,
+        cpus_solver: int | EllipsisType = ...,
         generator_battle_input: Encodable | None = None,
         solver_battle_input: Encodable | None = None,
         generator_battle_output: type[Encodable] | None = None,


### PR DESCRIPTION
A new version of pyright now complains about ellipsis default values without explicitly including them in the types in function implementations, so we need to marginally change some typings.