### PR TITLE
Add problem packaging

### DIFF
--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -532,7 +532,8 @@ def package_problem(
     if out is None:
         out = project / f"{problem_name.lower().replace(' ', '_')}.algo"
     with console.status("Packaging data"), ZipFile(out, "w") as file:
-        file.write(parsed_config.problem.location, "problem.py")
+        if parsed_config.problem.location.exists():
+            file.write(parsed_config.problem.location, "problem.py")
         file.writestr("algobattle.toml", dumps_toml(config_doc))
         if description is not None:
             file.write(description, description.name)

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -346,8 +346,10 @@ def init(
         if not res_path.is_absolute():
             res_path = target / res_path
         res_path.mkdir(parents=True, exist_ok=True)
+        gitignore = "*.algo\n*.prob\n"
         if res_path.resolve().is_relative_to(target.resolve()):
-            target.joinpath(".gitignore").write_text(f"{res_path.relative_to(target)}/\n")
+            gitignore += f"{res_path.relative_to(target)}/\n"
+        target.joinpath(".gitignore").write_text(gitignore)
 
     problem_obj = parsed_config.loaded_problem
     if schemas:

--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -4,7 +4,6 @@ Provides a command line interface to start matches and observe them. See `battle
 """
 from enum import StrEnum
 from functools import cached_property
-from itertools import count
 import json
 import operator
 from os import environ

--- a/algobattle/problem.py
+++ b/algobattle/problem.py
@@ -12,7 +12,6 @@ from typing import (
     Callable,
     ClassVar,
     Literal,
-    Mapping,
     ParamSpec,
     Protocol,
     Self,
@@ -215,12 +214,6 @@ def default_score(
         return max(0, min(1, solution.score(instance, Role.solver)))
 
 
-class DynamicProblemInfo(Protocol):
-    """Defines the metadadata needed to dynamically import a problem."""
-
-    location: Path
-
-
 class Problem:
     """The definition of a problem."""
 
@@ -347,20 +340,19 @@ class Problem:
             return cls._problems[name]
 
     @classmethod
-    def load(cls, name: str, dynamic: Mapping[str, DynamicProblemInfo]) -> Self:
+    def load(cls, name: str, file: Path | None = None) -> Self:
         """Loads the problem with the given name.
 
         Args:
             name: The name of the Problem to use.
-            dynamic: Metadata used to dynamically import a problem if needed.
+            file: Path to a file containing this problem.
 
         Raises:
             ValueError: If the problem is not specified properly
             RuntimeError: If the problem's dynamic import fails
         """
-        if name in dynamic:
-            info = dynamic[name]
-            return cls.load_file(name, info.location)
+        if file:
+            return cls.load_file(name, file)
         if name in cls._problems:
             return cls._problems[name]
         match list(entry_points(group="algobattle.problem", name=name)):

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -117,15 +117,15 @@ structure with both keys being mandatory:
     `solver`
     : Path to the team's solver.
 
-### `problems`
-: Contains data specifying how to dynamically import problems. Keys are problem names and values tables like this:
+### `problem`
+: Contains data specifying how to dynamically import the problem.
 
     !!! note
         This table is usually filled in by the course administrators, if you're a student you probably won't have to
         worry about it.
 
     `location`
-    : Path to the problem module. Defaults to `problem.py`, but we recommend to always specify this to make it explicit.
+    : Path to the problem module. Defaults to `problem.py`.
 
     `dependencies`
     : A list of [PEP 508](https://peps.python.org/pep-0508/) conformant dependency specification strings. These will be

--- a/docs/tutorial/getting_started.md
+++ b/docs/tutorial/getting_started.md
@@ -109,15 +109,9 @@ Project level configuration is done inside the `algobattle.toml` file so let's t
 problem = "Pairsum"
 # there might be more settings here
 
-[problems."Pairsum"]
-location = "problem.py"
-
 [teams."Red Pandas"]
 generator = "generator"
 solver = "solver"
-
-[project]
-results = "results"
 ```
 ///
 
@@ -129,16 +123,13 @@ problem = "Pairsum"
 [teams."Red Pandas"]
 generator = "generator"
 solver = "solver"
-
-[project]
-results = "results"
 ```
 ///
 
 The config file is split into a few tables, `match` specifies exactly what each Algobattle match is going to look like.
 This means that you will probably never want to change things in there since you want to develop your programs for the
 same conditions they're going to see during the scored matches run on the server. Feel free to play with the `teams`,
-`problems`, and `project` tables as much as you want, nothing in them affects the structure of the match or anything
+`problem`, and `project` tables as much as you want, nothing in them affects the structure of the match or anything
 on the server. In particular, the team name used here doesn't need to match the one used on your Algobattle website.
 The filled in settings so far all just are paths to where Algobattle can find certain files or folders. There's a lot
 more things you can configure, but we're happy with the default values for now.

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -7,7 +7,16 @@ from pathlib import Path
 from pydantic import ByteSize, ValidationError
 
 from algobattle.battle import Fight, Iterated, Averaged
-from algobattle.match import DynamicProblemConfig, MatchupStr, ProjectConfig, Match, AlgobattleConfig, MatchConfig, RunConfig, TeamInfo
+from algobattle.match import (
+    DynamicProblemConfig,
+    MatchupStr,
+    ProjectConfig,
+    Match,
+    AlgobattleConfig,
+    MatchConfig,
+    RunConfig,
+    TeamInfo,
+)
 from algobattle.program import ProgramRunInfo, Team, Matchup, TeamHandler
 from .testsproblem.problem import TestProblem
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pydantic import ByteSize, ValidationError
 
 from algobattle.battle import Fight, Iterated, Averaged
-from algobattle.match import MatchupStr, ProjectConfig, Match, AlgobattleConfig, MatchConfig, RunConfig, TeamInfo
+from algobattle.match import DynamicProblemConfig, MatchupStr, ProjectConfig, Match, AlgobattleConfig, MatchConfig, RunConfig, TeamInfo
 from algobattle.program import ProgramRunInfo, Team, Matchup, TeamHandler
 from .testsproblem.problem import TestProblem
 
@@ -236,6 +236,7 @@ class Parsing(TestCase):
                     battle=Averaged.Config(num_fights=1),
                 ),
                 project=ProjectConfig(points=10, results=self.configs_path / "results"),
+                problem=DynamicProblemConfig(location=self.configs_path / "problem.py"),
             ),
         )
 
@@ -252,6 +253,7 @@ class Parsing(TestCase):
                     problem="Test Problem",
                 ),
                 project=ProjectConfig(results=self.configs_path / "results"),
+                problem=DynamicProblemConfig(location=self.configs_path / "problem.py"),
             ),
         )
 


### PR DESCRIPTION
This moves the `algobattle package` command to `algobattle package problem` and adds `algobattle package programs`. The latter just zips up the programs into zipfiles compatible with our matches. In order to make all this a lot simpler this also simplifies the algobattle config structure a little. The old
```toml
[match]
problem = "Some Problem"
# ...

[problems."Some Problem"]
location = "problem.py"
```
now simply is
```toml
[match]
problem = "Some Problem"
# ...

[problem]
location = "problem.py"
```
And since "problem.py" now is the default location we can just do
```toml
[match]
problem = "Some Problem"
# ...
```
the vast majority of the time now.