### PR TITLE
Improve iterated battles

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -392,7 +392,7 @@ class Iterated(Battle):
 
         type: Literal["Iterated"] = "Iterated"
 
-        rounds: int = 5
+        rounds: int = 3
         """Number of times the instance size will be increased until the solver fails to produce correct solutions."""
         maximum_size: int = 50_000
         """Maximum instance size that will be tried."""

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -429,9 +429,10 @@ class Iterated(Battle):
         def sizes(size: int, max_size: int) -> Iterable[int]:
             counter = count(1)
             size = max(size, min_size)
-            while size <= max_size:
+            while size < max_size:
                 yield size
                 size += next(counter) ** config.exponent
+            yield max_size
 
         note = "Starting battle..."
         for _ in range(config.rounds):

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -155,11 +155,7 @@ class IteratedTests(IsolatedAsyncioTestCase):
         await self._expect_fights(always(fail), [1])
         await self._expect_fights(
             always(succ),
-            [1, 2, 6, 15, 31, 56, 92, 141, 205, 286, 386, 507, 651, 820]
-            + [821, 822, 826, 835, 851, 876, 912, 961]
-            + [962, 963, 967, 976, 992]
-            + [993, 994, 998]
-            + [999, 1000],
+            [1, 2, 6, 15, 31, 56, 92, 141, 205, 286, 386, 507, 651, 820, 1000],
             score=1000,
             total=True,
         )


### PR DESCRIPTION
Makes the number of rounds in iterated battles default to 3 instead of 5, and makes it go to the cap if it was stepped over instead of iterating up to it. Unfortunately, the latter change doesn't actually have a big impact in real-world-ish cases. E.g. here are the number of fights measured over 1000 battles with probabilistic teams:
![image](https://github.com/Benezivas/algobattle/assets/59090860/d52fc54b-dfeb-4efb-bb05-5680cec75f05)

But it still is better behaviour so it's good to make it work like this.