### PR TITLE
Improved match logs

### DIFF
--- a/algobattle/cli.py
+++ b/algobattle/cli.py
@@ -183,9 +183,8 @@ def run_match(
                 console.print(Padding(leaderboard, (1, 0, 0, 0)))
 
             if save:
-                res_string = result.model_dump_json(exclude_defaults=True)
                 out_path = config.project.results.joinpath(f"match-{timestamp()}.json")
-                out_path.write_text(res_string)
+                out_path.write_text(result.format(error_detail=config.project.error_detail))
                 console.print("Saved match result to ", out_path)
             return result
         except KeyboardInterrupt:

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -27,7 +27,15 @@ from anyio import create_task_group, CapacityLimiter
 from anyio.to_thread import current_default_thread_limiter
 from docker.types import LogConfig, Ulimit
 
-from algobattle.battle import Battle, FightHandler, FightUi, BattleUi, Iterated
+from algobattle.battle import (
+    Battle,
+    FightHandler,
+    FightUi,
+    BattleUi,
+    Iterated,
+    ProgramLogConfigLocation,
+    ProgramLogConfigTime,
+)
 from algobattle.program import ProgramConfigView, ProgramUi, Matchup, TeamHandler, BuildUi
 from algobattle.problem import Problem
 from algobattle.util import (
@@ -90,6 +98,7 @@ class Match(BaseModel):
                 battle=battle,
                 ui=battle_ui,
                 set_cpus=set_cpus,
+                log_config=config.project.log_program_io,
             )
             try:
                 await battle.run_battle(
@@ -604,6 +613,13 @@ class DynamicProblemConfig(BaseModel):
 class ProjectConfig(BaseModel):
     """Various project settings."""
 
+    class ProgramOutputConfig(BaseModel):
+        """How to log program output."""
+
+        # a bit janky atm, allows for future expansion
+        when: ProgramLogConfigTime = ProgramLogConfigTime.error
+        output: ProgramLogConfigLocation = ProgramLogConfigLocation.inline
+
     parallel_battles: int = 1
     """Number of battles exectuted in parallel."""
     name_images: bool = True
@@ -616,6 +632,8 @@ class ProjectConfig(BaseModel):
     """How detailed error messages should be.
     Higher settings help in debugging, but may leak information from other teams.
     """
+    log_program_io: ProgramOutputConfig = ProgramOutputConfig()
+    """How to log program output."""
     points: int = 100
     """Highest number of points each team can achieve."""
     results: RelativePath = Field(default=Path("./results"), validate_default=True)

--- a/algobattle/program.py
+++ b/algobattle/program.py
@@ -828,8 +828,6 @@ class TeamHandler:
             except Exception as e:
                 handler.excluded[name] = ExceptionInfo.from_exception(e)
                 ui.finish_build(name, False)
-            except BaseException:
-                raise
             else:
                 ui.finish_build(name, True)
         return handler

--- a/algobattle/types.py
+++ b/algobattle/types.py
@@ -457,12 +457,12 @@ class EdgeLen:
 
     @staticmethod
     def _func(v: Any, edges: list[tuple[int, int]]) -> Any:
-        """Validates that the collection has length `instance.size`."""
+        """Validates that the collection has the same length as `instance.edges`."""
         if len(v) != len(edges):
-            raise ValueError("Value does not have length `instance.size`")
+            raise ValueError("Value does not have the same length as `instance.edges`")
         return v
 
-    _validator = AttributeReferenceValidator(_func, InstanceRef.size)
+    _validator = AttributeReferenceValidator(_func, InstanceRef.edges)
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -207,7 +207,7 @@ class ExceptionInfo(BaseModel):
         else:
             return cls(
                 type=error.__class__.__name__,
-                message=str(error),
+                message="Unknown exception occurred.",
                 detail=format_exception(error),
             )
 

--- a/algobattle/util.py
+++ b/algobattle/util.py
@@ -35,7 +35,7 @@ T = TypeVar("T")
 class BaseModel(PydandticBaseModel):
     """Base class for all pydantic models."""
 
-    model_config = ConfigDict(extra="forbid", from_attributes=True)
+    model_config = ConfigDict(extra="forbid", from_attributes=True, hide_input_in_errors=True)
 
 
 class Encodable(ABC):
@@ -197,6 +197,12 @@ class ExceptionInfo(BaseModel):
                 type=error.__class__.__name__,
                 message=error.message,
                 detail=error.detail,
+            )
+        elif isinstance(error, PydanticValidationError):
+            return cls(
+                type=error.__class__.__name__,
+                message=str(error),
+                detail=str(error.errors(include_input=True, include_url=False)),
             )
         else:
             return cls(

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -173,6 +173,11 @@ structure with both keys being mandatory:
     : Path to the folder where result files are saved. Each result file will be a json file with a name containing the
     command that created it and the current timestamp. Defaults to `results`
 
+    `error_detail`
+    : Used to specify how detailed error messages included in the log files should be. Can be set to `high`, which
+    includes full details and stack traces for any exceptions that occur, or `low` to hide sensitive data that may leak
+    other team's strategic information.
+
 ### `docker`
 : Contains various advanced Docker settings that are passed through to the Docker daemon without influencing Algobattle
 itself. You generally should not need to use these settings. If you are running into a problem you cannot solve without

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -178,6 +178,18 @@ structure with both keys being mandatory:
     includes full details and stack traces for any exceptions that occur, or `low` to hide sensitive data that may leak
     other team's strategic information.
 
+    `log_program_io`
+    : A table that specifies how each program's output should be logged.
+
+        `when`
+        : When to save the data. Can be either `never`, `error`, or `always`. When set to `never` or `always` it has the
+        expected behaviour, when set to `error` it will save the data only if an error occurred during the fight.
+        Defaults to `error`.
+
+        `output`
+        : Where to store each program's output data. Currently only supports `disabled` to turn of logging program output
+        or `inline` to store jsonable data in the match result json file. Defaults to `inline.`
+
 ### `docker`
 : Contains various advanced Docker settings that are passed through to the Docker daemon without influencing Algobattle
 itself. You generally should not need to use these settings. If you are running into a problem you cannot solve without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "algobattle-base"
-version = "4.0.3"
+version = "4.1.0"
 description = "The Algobattle lab course package."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "algobattle-base"
-version = "4.0.2"
+version = "4.0.3"
 description = "The Algobattle lab course package."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -5,9 +5,9 @@ from types import EllipsisType
 from typing import Iterable, TypeVar
 from unittest import IsolatedAsyncioTestCase, main
 
-from algobattle.battle import Battle, Fight, FightHandler, Iterated
+from algobattle.battle import Battle, Fight, FightHandler, Iterated, ProgramRunInfo
 from algobattle.match import BattleObserver, EmptyUi
-from algobattle.program import Matchup, ProgramRunInfo, Team
+from algobattle.program import Matchup, Team
 from algobattle.util import Encodable, ExceptionInfo
 
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -35,7 +35,7 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "generator_timeout", problem=TestProblem, config=self.config_short
         ) as gen:
             res = await gen.run(5)
-            self.assertIsNone(res.info.error)
+            self.assertIsNone(res.error)
 
     async def test_gen_strict_timeout(self):
         """The generator times out."""
@@ -45,8 +45,8 @@ class ProgramTests(IsolatedAsyncioTestCase):
             config=self.config_strict,
         ) as gen:
             res = await gen.run(5)
-            assert res.info.error is not None
-            self.assertEqual(res.info.error.type, "ExecutionTimeout")
+            assert res.error is not None
+            self.assertEqual(res.error.type, "ExecutionTimeout")
 
     async def test_gen_exec_err(self):
         """The generator doesn't execute properly."""
@@ -54,8 +54,8 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "generator_execution_error", problem=TestProblem, config=self.config
         ) as gen:
             res = await gen.run(5)
-            assert res.info.error is not None
-            self.assertEqual(res.info.error.type, "ExecutionError")
+            assert res.error is not None
+            self.assertEqual(res.error.type, "ExecutionError")
 
     async def test_gen_syn_err(self):
         """The generator outputs a syntactically incorrect solution."""
@@ -63,8 +63,8 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "generator_syntax_error", problem=TestProblem, config=self.config
         ) as gen:
             res = await gen.run(5)
-            assert res.info.error is not None
-            self.assertEqual(res.info.error.type, "EncodingError")
+            assert res.error is not None
+            self.assertEqual(res.error.type, "EncodingError")
 
     async def test_gen_sem_err(self):
         """The generator outputs a semantically incorrect solution."""
@@ -72,8 +72,8 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "generator_semantics_error", problem=TestProblem, config=self.config
         ) as gen:
             res = await gen.run(5)
-            assert res.info.error is not None
-            self.assertEqual(res.info.error.type, "ValidationError")
+            assert res.error is not None
+            self.assertEqual(res.error.type, "ValidationError")
 
     async def test_gen_succ(self):
         """The generator returns the fixed instance."""
@@ -90,8 +90,8 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "solver_timeout", problem=TestProblem, config=self.config_strict
         ) as sol:
             res = await sol.run(self.instance, 5)
-            assert res.info.error is not None
-            self.assertEqual(res.info.error.type, "ExecutionTimeout")
+            assert res.error is not None
+            self.assertEqual(res.error.type, "ExecutionTimeout")
 
     async def test_sol_lax_timeout(self):
         """The solver times out but still outputs a correct solution."""
@@ -99,7 +99,7 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "solver_timeout", problem=TestProblem, config=self.config_short
         ) as sol:
             res = await sol.run(self.instance, 5)
-            self.assertIsNone(res.info.error)
+            self.assertIsNone(res.error)
 
     async def test_sol_exec_err(self):
         """The solver doesn't execute properly."""
@@ -107,8 +107,8 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "solver_execution_error", problem=TestProblem, config=self.config
         ) as sol:
             res = await sol.run(self.instance, 5)
-            assert res.info.error is not None
-            self.assertEqual(res.info.error.type, "ExecutionError")
+            assert res.error is not None
+            self.assertEqual(res.error.type, "ExecutionError")
 
     async def test_sol_syn_err(self):
         """The solver outputs a syntactically incorrect solution."""
@@ -116,8 +116,8 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "solver_syntax_error", problem=TestProblem, config=self.config
         ) as sol:
             res = await sol.run(self.instance, 5)
-            assert res.info.error is not None
-            self.assertEqual(res.info.error.type, "EncodingError")
+            assert res.error is not None
+            self.assertEqual(res.error.type, "EncodingError")
 
     async def test_sol_sem_err(self):
         """The solver outputs a semantically incorrect solution."""
@@ -125,8 +125,8 @@ class ProgramTests(IsolatedAsyncioTestCase):
             path=self.problem_path / "solver_semantics_error", problem=TestProblem, config=self.config
         ) as sol:
             res = await sol.run(self.instance, 5)
-            assert res.info.error is not None
-            self.assertEqual(res.info.error.type, "ValidationError")
+            assert res.error is not None
+            self.assertEqual(res.error.type, "ValidationError")
 
     async def test_sol_succ(self):
         """The solver outputs a solution with a low quality."""

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from pydantic import ByteSize, ValidationError
 
-from algobattle.battle import Fight, Iterated, Averaged
+from algobattle.battle import Fight, Iterated, Averaged, ProgramRunInfo
 from algobattle.match import (
     DynamicProblemConfig,
     MatchupStr,
@@ -17,7 +17,7 @@ from algobattle.match import (
     RunConfig,
     TeamInfo,
 )
-from algobattle.program import ProgramRunInfo, Team, Matchup, TeamHandler
+from algobattle.program import Team, Matchup, TeamHandler
 from .testsproblem.problem import TestProblem
 
 


### PR DESCRIPTION
This updates the json match logs in two ways: Firstly, it addresses #144 by adding the option to only include the "message" part of each raised error, and not the "detail". This stops user code from intentionally crashing and outputting hidden data. Secondly, it adds options that let you include program output in the match result. These options are intentionally formatted in a somewhat strange way to leave room for future expansion. The current implementation only does the most straightforward part of this general idea, but should cover most use cases.