### PR TITLE
Improved algobattle init cli

### DIFF
--- a/algobattle/templates/__init__.py
+++ b/algobattle/templates/__init__.py
@@ -70,3 +70,18 @@ def write_templates(target: Path, lang: Language, args: TemplateArgs) -> None:
         (target / formatted_path).parent.mkdir(parents=True, exist_ok=True)
         with open(target / formatted_path, "w+") as file:
             file.write(formatted)
+
+
+problem_env = Environment(
+    loader=PackageLoader("algobattle"),
+    keep_trailing_newline=True,
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+def write_problem_template(target: Path, name: str) -> None:
+    """Writes the problem.py template to the targeted file."""
+    template = problem_env.get_template("problem.py.jinja")
+    formatted = template.render({"name": name})
+    target.write_text(formatted)

--- a/algobattle/templates/problem.py.jinja
+++ b/algobattle/templates/problem.py.jinja
@@ -1,0 +1,31 @@
+"""The {{ name }} problem module."""
+from algobattle.problem import Problem, InstanceModel, SolutionModel, maximize
+from algobattle.util import Role
+
+
+class Instance(InstanceModel):
+    """Instances of {{ name }}."""
+
+    ...
+
+    @property
+    def size(self) -> int:
+        ...
+
+
+class Solution(SolutionModel[Instance]):
+    """Solutions of {{ name }}."""
+
+    ...
+
+    @maximize
+    def score(self, instance: Instance, role: Role) -> float:
+        ...
+
+
+Problem(
+    name="{{ name }}",
+    min_size=1,
+    instance_cls=Instance,
+    solution_cls=Solution,
+)


### PR DESCRIPTION
This improves the cli interaction of `algobattle init` in two ways:

1. It cleans up the help message my moving the language choices into a neater display at the bottom.
2. It adds the `--new` flag to enable creating entirely new projects with a blank problem template. You can then use eg `algobattle init --new -p "Very Fancy Problem" -l python` to create a new folder for the Very Fancy Problem that already contains templates for the problem file, a blank config, and generator/solver templates. This addresses #150.