### PR TITLE
Add the Improving battle type

### DIFF
--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -736,9 +736,10 @@ class Improving(Battle):
         if len(self.fights) == 0:
             return 0
         else:
-            return sum(f.score * (1 + config.weighting / 100) ** i for (i, f) in enumerate(self.fights)) / len(
-                self.fights
-            )
+            weight = 1 + config.weighting / 100
+            total = sum(f.score * weight ** i for (i, f) in enumerate(self.fights))
+            quotient = (1 - weight ** len(self.fights)) / (1 - weight)
+            return total / quotient
 
     @staticmethod
     def format_score(score: float) -> str:  # noqa: D102

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -178,6 +178,8 @@ class FightUi(ProgramUi, Protocol):
 
 
 class RunKwargs(TypedDict, total=False):
+    """The keyword arguments used by the FightHandler.run family of functions."""
+
     timeout_generator: float | None
     space_generator: int | None
     cpus_generator: int
@@ -330,6 +332,17 @@ class FightHandler:
         return gen_result, sol_result
 
     def calculate_score(self, gen_result: GeneratorResult, sol_result: SolverResult) -> float:
+        """Calculates the score achieved by the solver in this fight.
+
+        Both results need to contain all instance and/or solution data required.
+
+        Args:
+            gen_result: The generator's result.
+            sol_result: The solver's result
+
+        Returns:
+            A number in [0, 1] with higher numbers meaning the solver performed better.
+        """
         assert gen_result.instance is not None
         assert sol_result.solution is not None
         if self.problem.with_solution:
@@ -656,6 +669,8 @@ class FightHistory(Encodable):
 
     @dataclass
     class Fight:
+        """The full data of a single fight."""
+
         score: float
         generator: GeneratorResult
         solver: SolverResult | None
@@ -666,7 +681,7 @@ class FightHistory(Encodable):
     gen_sols: set[Role]
     sol_sols: set[Role]
 
-    def encode(self, target: Path, role: Role) -> None:
+    def encode(self, target: Path, role: Role) -> None:  # noqa: D102
         target.mkdir()
         for i, fight in enumerate(self.history):
             fight_dir = target / str(i)
@@ -688,7 +703,6 @@ class FightHistory(Encodable):
 
 class Improving(Battle):
     """Class that executes an improving battle."""
-
 
     class Config(Battle.Config):
         """Config options for Improving battles."""
@@ -720,7 +734,12 @@ class Improving(Battle):
         """
         if config.instance_size < min_size:
             raise ValueError(f"size {config.instance_size} is smaller than the smallest valid size, {min_size}.")
-        history = FightHistory(scores=config.scores, instances=config.instances, gen_sols=config.generator_solutions, sol_sols=config.solver_solutions)
+        history = FightHistory(
+            scores=config.scores,
+            instances=config.instances,
+            gen_sols=config.generator_solutions,
+            sol_sols=config.solver_solutions,
+        )
         for i in range(config.num_fights):
             ui.update_battle_data(self.UiData(round=i + 1))
             plain_fight, gen, sol = await fight.run(
@@ -737,7 +756,7 @@ class Improving(Battle):
             return 0
         else:
             weight = 1 + config.weighting / 100
-            total = sum(f.score * weight ** i for (i, f) in enumerate(self.fights))
+            total = sum(f.score * weight**i for (i, f) in enumerate(self.fights))
             quotient = (1 - weight ** len(self.fights)) / (1 - weight)
             return total / quotient
 

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -439,7 +439,7 @@ class Battle(BaseModel):
         return super().__pydantic_init_subclass__(**kwargs)
 
     @abstractmethod
-    def score(self) -> float:
+    def score(self, config: _BattleConfig) -> float:
         """Calculates the score the solver has achieved during this battle.
 
         Should always be a nonnegative float, with higher values indicating a better performance of the solver.
@@ -560,7 +560,7 @@ class Iterated(Battle):
                         self.results[-1] = size
             note = "Cap reached, resetting instance size"
 
-    def score(self) -> float:
+    def score(self, config: Config) -> float:
         """Averages the highest instance size reached in each round."""
         return 0 if len(self.results) == 0 else sum(self.results) / len(self.results)
 
@@ -596,7 +596,7 @@ class Averaged(Battle):
             ui.update_battle_data(self.UiData(round=i + 1))
             await fight.run(config.instance_size)
 
-    def score(self) -> float:
+    def score(self, config: Config) -> float:
         """Averages the score of each fight."""
         if len(self.fights) == 0:
             return 0

--- a/algobattle/battle.py
+++ b/algobattle/battle.py
@@ -713,7 +713,7 @@ class Improving(Battle):
         """Instance size that will be fought at."""
         num_fights: int = 20
         """Number of fights that will be fought."""
-        weighting: Annotated[int, Ge(1)] = 10
+        weighting: Annotated[float, Ge(0)] = 1.1
         """How much each successive fight should be weighted more than the previous."""
         scores: set[Role] = {Role.generator, Role.solver}
         """Who to show each fight's scores to."""
@@ -755,9 +755,8 @@ class Improving(Battle):
         if len(self.fights) == 0:
             return 0
         else:
-            weight = 1 + config.weighting / 100
-            total = sum(f.score * weight**i for (i, f) in enumerate(self.fights))
-            quotient = (1 - weight ** len(self.fights)) / (1 - weight)
+            total = sum(f.score * config.weighting**i for (i, f) in enumerate(self.fights))
+            quotient = (1 - config.weighting ** len(self.fights)) / (1 - config.weighting)
             return total / quotient
 
     @staticmethod

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -174,7 +174,9 @@ class Match(BaseModel):
                 second_res = self.battles[MatchupStr(first, second)]
             except KeyError:
                 continue
-            total_score = max(0, first_res.score(self.config.match.battle)) + max(0, second_res.score(self.config.match.battle))
+            total_score = max(0, first_res.score(self.config.match.battle)) + max(
+                0, second_res.score(self.config.match.battle)
+            )
             if total_score == 0:
                 # Default values for proportions, assuming no team manages to solve anything
                 first_ratio = 0.5

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -1,5 +1,5 @@
 """Module defining how a match is run."""
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import cached_property
 from itertools import combinations
@@ -74,8 +74,8 @@ class MatchupStr:
 class Match(BaseModel):
     """The Result of a whole Match."""
 
-    active_teams: list[str] = field(default_factory=list)
-    excluded_teams: dict[str, ExceptionInfo] = field(default_factory=dict)
+    active_teams: list[str] = Field(default_factory=list)
+    excluded_teams: dict[str, ExceptionInfo] = Field(default_factory=dict)
     battles: dict[MatchupStr, SerializeAsAny[Battle]] = Field(default_factory=dict)
 
     async def _run_battle(

--- a/algobattle/match.py
+++ b/algobattle/match.py
@@ -74,6 +74,7 @@ class MatchupStr:
 class Match(BaseModel):
     """The Result of a whole Match."""
 
+    config: "AlgobattleConfig" = Field(exclude=True)
     active_teams: list[str] = Field(default_factory=list)
     excluded_teams: dict[str, ExceptionInfo] = Field(default_factory=dict)
     battles: dict[MatchupStr, SerializeAsAny[Battle]] = Field(default_factory=dict)
@@ -82,7 +83,6 @@ class Match(BaseModel):
         self,
         battle: Battle,
         matchup: Matchup,
-        config: "AlgobattleConfig",
         problem: Problem,
         cpus: list[str | None],
         ui: "Ui",
@@ -99,12 +99,12 @@ class Match(BaseModel):
                 battle=battle,
                 ui=battle_ui,
                 set_cpus=set_cpus,
-                log_config=config.project.log_program_io,
+                log_config=self.config.project.log_program_io,
             )
             try:
                 await battle.run_battle(
                     handler,
-                    config.match.battle,
+                    self.config.match.battle,
                     problem.min_size,
                     battle_ui,
                 )
@@ -115,7 +115,6 @@ class Match(BaseModel):
 
     async def run(
         self,
-        config: "AlgobattleConfig",
         ui: "Ui | None" = None,
     ) -> Self:
         """Runs a match with the given config settings and problem type.
@@ -129,7 +128,7 @@ class Match(BaseModel):
         """
         if ui is None:
             ui = EmptyUi()
-        ui.match = self
+        config = self.config
         problem = config.loaded_problem
 
         with await TeamHandler.build(config.teams, problem, config.as_prog_config(), ui) as teams:
@@ -148,10 +147,10 @@ class Match(BaseModel):
                 for matchup in teams.matchups:
                     battle = battle_cls()
                     self.battles[MatchupStr.make(matchup)] = battle
-                    tg.start_soon(self._run_battle, battle, matchup, config, problem, match_cpus, ui, limiter)
+                    tg.start_soon(self._run_battle, battle, matchup, problem, match_cpus, ui, limiter)
         return self
 
-    def calculate_points(self, total_points_per_team: int) -> dict[str, float]:
+    def calculate_points(self) -> dict[str, float]:
         """Calculate the number of points each team scored.
 
         Every team scores between 0 and `total_points_per_team` points.
@@ -159,6 +158,7 @@ class Match(BaseModel):
         The other teams each get points based on how well they did against each other team compared to how well that
         other team did against them.
         """
+        total_points_per_team = self.config.project.points
         points = {team: 0.0 for team in self.active_teams + list(self.excluded_teams)}
         if len(self.active_teams) == 0:
             return points
@@ -174,14 +174,14 @@ class Match(BaseModel):
                 second_res = self.battles[MatchupStr(first, second)]
             except KeyError:
                 continue
-            total_score = max(0, first_res.score()) + max(0, second_res.score())
+            total_score = max(0, first_res.score(self.config.match.battle)) + max(0, second_res.score(self.config.match.battle))
             if total_score == 0:
                 # Default values for proportions, assuming no team manages to solve anything
                 first_ratio = 0.5
                 second_ratio = 0.5
             else:
-                first_ratio = first_res.score() / total_score
-                second_ratio = second_res.score() / total_score
+                first_ratio = first_res.score(self.config.match.battle) / total_score
+                second_ratio = second_res.score(self.config.match.battle) / total_score
 
             points[first] += round(points_per_matchup * first_ratio, 1)
             points[second] += round(points_per_matchup * second_ratio, 1)

--- a/docs/advanced/battle_types.md
+++ b/docs/advanced/battle_types.md
@@ -92,3 +92,80 @@ Averaged battles display a single value to the UI:
 
 round
 : The current round that is being fought.
+
+
+## Improving
+
+The idea behind this battle type is that the teams don't just create the best possible instances and solutions out of
+thin air, but try to learn over time and improve their output. We run multiple rounds, similar to
+[Averaged battles](#averaged), but programs will also receive information about the previous round's result. By default,
+this includes their score, the instances, and each program's own solutions.
+
+!!! example "Example program input"
+    Using the default settings and the Pairsum problem, in the third round the solver would see an input folder
+    like this:
+
+    ``` { .sh .no-copy }
+    /input
+    ├─ instance.json
+    ├─ info.json
+    └─ battle_data/
+       ├─ 0/
+       │  ├─ score.txt
+       │  ├─ instance.json
+       │  └─ solver_solution.json
+       └─ 1/
+           ├─ score.txt
+           ├─ instance.json
+           └─ solver_solution.json
+    ```
+
+    The `instance.json` file contains the actual instance that needs to be solved this round. The folders in
+    `/input/battle_data` are named after the index of each previous fight and contain that fight's data.
+
+!!! attention "Missing files"
+    The instance and solution files may be missing in some or all of the fights. This happens if e.g. one of the
+    programs crashes or outputs invalid data. In those cases the battle will continue with the corresponding files
+    not existing in the input folder. Always check if the files are actually there and have a fallback ready!
+
+You can also configure this battle type to only include some of this information or reveal even more details about the
+previous fights to each team. This can lead to interesting challenges where e.g. every instance and generator's solution
+is fully revealed and the generating team thus needs to come up with very different instances every run.
+
+The overall score is calculated by averaging each round's score, but with later fights being weighted more. This means
+that cleverly using the given information about previous fights is more important than just having strong programs.
+
+### Config
+
+`instance_size`
+: The instance size every fight in each match will be fought at. Defaults to 25.
+
+`num_fights`
+: The number of fights that will be fought in each match. Defaults to 10.
+
+`weighting`
+: How much additional weight each successive fight receives in the overall score. Needs to be a positive integer that
+expresses percentages. E.g. a `weighting` of `2` means the second fight is twice as impactful as the first, the third
+four times, etc. Note that series exhibits exponential growth and thus `weightings` close to `1` should be used to not
+make all but the last few fights matter. Defaults to `1.1`.
+
+`scores`
+: A set of roles (a role is either `#!toml "generator"` or `#!toml "solver"`) that specifies which programs will see
+each previous rounds' scores. Defaults to `#!toml ["generator", "solver"]`.
+
+`instances`
+: Similar to `scores` but regarding the problem instances. Defaults to `#!toml ["generator", "solver"]`.
+
+`generator_solutions`
+: Similar to `scores` but regarding the generator's solutions (if the problem uses them). Defaults to
+`#!toml ["generator"]`.
+
+`solver_solutions`
+: Similar to `scores` but regarding the solver's solutions. Defaults to `#!toml ["solver"]`.
+
+### UI Data
+
+Improving battles display a single value to the UI:
+
+round
+: The current round that is being fought.

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -126,7 +126,7 @@ class IteratedTests(IsolatedAsyncioTestCase):
         battle = Iterated()
         handler = ConstantHandler(battle, size)
         await battle.run_battle(handler, self.config, 1, self.ui)
-        self.assertEqual(size, battle.score())
+        self.assertEqual(size, battle.score(self.config))
         return battle
 
     async def test_sizes(self) -> None:
@@ -148,7 +148,7 @@ class IteratedTests(IsolatedAsyncioTestCase):
             fought_sizes = fought_sizes[: len(sizes)]
         self.assertEqual(sizes, fought_sizes)
         if score is not None:
-            self.assertEqual(battle.score(), score)
+            self.assertEqual(battle.score(self.config), score)
         return battle
 
     async def test_full_battle(self) -> None:

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from itertools import chain, cycle
 from types import EllipsisType
-from typing import Iterable, TypeVar
+from typing import Any, Iterable, TypeVar
 from unittest import IsolatedAsyncioTestCase, main
 
 from algobattle.battle import Battle, Fight, FightHandler, Iterated, ProgramRunInfo
@@ -62,7 +62,8 @@ class TestHandler(FightHandler):
         solver_battle_input: Encodable | None = None,
         generator_battle_output: type[Encodable] | None = None,
         solver_battle_output: type[Encodable] | None = None,
-    ) -> Fight:
+        with_results: bool = False,
+    ) -> Any:
         f = None
         match next(self.results):
             case Result.generator_err:
@@ -106,7 +107,8 @@ class ConstantHandler(FightHandler):
         solver_battle_input: Encodable | None = None,
         generator_battle_output: type[Encodable] | None = None,
         solver_battle_output: type[Encodable] | None = None,
-    ) -> Fight:
+        with_results: bool = False,
+    ) -> Any:
         f = Fight(
             score=float(max_size <= self.size), max_size=max_size, generator=ProgramRunInfo(), solver=ProgramRunInfo()
         )

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -1,14 +1,17 @@
 """Tests for the Battle types."""
 from enum import Enum
 from itertools import chain, cycle
+from pathlib import Path
 from types import EllipsisType
-from typing import Any, Iterable, TypeVar
-from unittest import IsolatedAsyncioTestCase, main
+from typing import Any, Iterable, TypeVar, Unpack, cast
+from unittest import IsolatedAsyncioTestCase, TestCase, main
+from uuid import uuid4
 
-from algobattle.battle import Battle, Fight, FightHandler, Iterated, ProgramRunInfo
+from algobattle.battle import Battle, Fight, FightHandler, FightHistory, Improving, Iterated, ProgramRunInfo, RunKwargs
 from algobattle.match import BattleObserver, EmptyUi
-from algobattle.program import Matchup, Team
-from algobattle.util import Encodable, ExceptionInfo
+from algobattle.program import GeneratorResult, Matchup, SolverResult, Team
+from algobattle.util import Encodable, ExceptionInfo, Role, TempDir
+from tests.testsproblem.problem import TestInstance, TestSolution
 
 
 T = TypeVar("T")
@@ -195,6 +198,196 @@ class IteratedTests(IsolatedAsyncioTestCase):
             [succ, succ, succ, e, e, succ, e, e, e], [1, 2, 6, 15, 31, 56, 92, 141, 205], score=205
         )
 
+
+class TrackingHandler(FightHandler):
+    """Fight handler that tracks the passed battle data."""
+
+    def __init__(self, battle: Improving, gen_res: Iterable[GeneratorResult], sol_res: Iterable[SolverResult | None]) -> None:
+        self.battle = battle
+        self.gen_res = iter(gen_res)
+        self.sol_res = iter(sol_res)
+        self.data: list[list[FightHistory.Fight]] = []
+
+    async def run(self, max_size: int, *, with_results: bool = False, **kwargs: Unpack[RunKwargs]) -> Any:
+        gen = kwargs.get("generator_battle_input")
+        sol = kwargs.get("solver_battle_input")
+        assert isinstance(gen, FightHistory)
+        assert gen == sol
+        self.data.append(list(gen.history))
+        return (
+            Fight(score=1, max_size=max_size, generator=ProgramRunInfo(), solver=ProgramRunInfo()),
+            next(self.gen_res),
+            next(self.sol_res),
+        )
+
+
+class ImprovingTests(IsolatedAsyncioTestCase):
+    """Tests for the Improving battle type itself."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.config = Improving.Config(num_fights=3)
+        cls.ui = BattleObserver(EmptyUi(), Matchup(TestTeam("Test"), TestTeam("Test")))
+        cls.history = FightHistory(scores=set(), instances=set(), gen_sols=set(), sol_sols=set())
+        cls.history.history = [
+            FightHistory.Fight(0.5, cls.gen_res(), cls.sol_res()),
+            FightHistory.Fight(1, cls.gen_res(), cls.sol_res()),
+        ]
+
+    async def run_battle(self, gen_res: Iterable[GeneratorResult], sol_res: Iterable[SolverResult | None], config: Improving.Config | None = None) -> TrackingHandler:
+        battle = Improving()
+        handler = TrackingHandler(battle, gen_res, sol_res)
+        await battle.run_battle(handler, config=config or self.config, min_size=5, ui=self.ui)
+        return handler
+
+    @staticmethod
+    def gen_res(instance: bool = True, solution: bool = True) -> GeneratorResult:
+        return GeneratorResult(
+            instance=TestInstance(semantics=True, extra=str(uuid4())) if instance else None,
+            solution=cast(Any, TestSolution(semantics=True, quality=True, extra=str(uuid4()))) if solution else None,
+        )
+
+    @staticmethod
+    def sol_res(solution: bool = True) -> SolverResult:
+        return SolverResult(
+            solution=cast(Any, TestSolution(semantics=True, quality=True, extra=str(uuid4()))) if solution else None,
+        )
+
+    async def test_first_fight_empty(self) -> None:
+        handler = await self.run_battle([self.gen_res()], [self.sol_res()], Improving.Config(num_fights=1))
+        self.assertEqual(len(handler.data), 1)
+        self.assertEqual(len(handler.data[0]), 0)
+
+    async def test_fights_tracked(self) -> None:
+        gen_res = [self.gen_res() for _ in range(3)]
+        sol_res = [self.sol_res() for _ in range(3)]
+        handler = await self.run_battle(gen_res, sol_res)
+        self.assertEqual(len(handler.data), 3)
+        for i, history in enumerate(handler.data):
+            self.assertEqual(history, [FightHistory.Fight(1, g, s) for (g, s) in zip(gen_res[:i], sol_res[:i])])
+
+    async def test_sol_none(self) -> None:
+        gen_res = [self.gen_res() for _ in range(3)]
+        sol_res = [self.sol_res(False), self.sol_res(), self.sol_res()]
+        handler = await self.run_battle(gen_res, sol_res)
+        sol = handler.data[-1][0].solver
+        self.assertIsNotNone(sol)
+        assert sol is not None
+        self.assertIsNone(sol.solution)
+
+    async def test_no_sol(self) -> None:
+        gen_res = [self.gen_res() for _ in range(3)]
+        sol_res = [None, self.sol_res(), self.sol_res()]
+        handler = await self.run_battle(gen_res, sol_res)
+        sol = handler.data[-1][0].solver
+        self.assertIsNone(sol)
+
+    async def test_no_witness(self) -> None:
+        gen_res = [self.gen_res(solution=False) for _ in range(3)]
+        sol_res = [self.sol_res(), self.sol_res(), self.sol_res()]
+        handler = await self.run_battle(gen_res, sol_res)
+        self.assertIsNotNone(handler.data[-1][0].generator.instance)
+        self.assertIsNone(handler.data[-1][0].generator.solution)
+
+    async def test_no_instance(self) -> None:
+        gen_res = [self.gen_res(instance=False) for _ in range(3)]
+        sol_res = [self.sol_res(), self.sol_res(), self.sol_res()]
+        handler = await self.run_battle(gen_res, sol_res)
+        self.assertIsNone(handler.data[-1][0].generator.instance)
+        self.assertIsNotNone(handler.data[-1][0].generator.solution)
+
+
+class FightHistoryEncoding(TestCase):
+    """Tests the encoding of the FightHistory class."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.history = FightHistory(scores=set(), instances=set(), gen_sols=set(), sol_sols=set())
+        cls.history.history = [
+            FightHistory.Fight(0.5, ImprovingTests.gen_res(), ImprovingTests.sol_res()),
+            FightHistory.Fight(1, ImprovingTests.gen_res(), ImprovingTests.sol_res()),
+        ]
+
+    @staticmethod
+    def role_sets() -> Iterable[set[Role]]:
+        yield {Role.generator}
+        yield {Role.solver}
+        yield {Role.generator, Role.solver}
+        yield set()
+
+    def _encode_attr(self, target: Path, attr: str) -> Iterable[tuple[int, Path, bool]]:
+        for roles in self.role_sets():
+            setattr(self.history, attr, roles)
+            yield from self._encode_role(target / str(uuid4()), Role.generator, roles)
+            yield from self._encode_role(target / str(uuid4()), Role.solver, roles)
+
+    def _encode_role(self, target: Path, role: Role, roles: set[Role]) -> Iterable[tuple[int, Path, bool]]:
+        self.history.encode(target, role)
+        for f in target.iterdir():
+            self.assertIn(f.name, {"0", "1"})
+        for f in target.iterdir():
+            yield int(f.name), f, role in roles
+
+    def test_encode_size(self) -> None:
+        with TempDir() as target:
+            for num, folder, should_exist in self._encode_attr(target, "scores"):
+                self.assertEqual(folder.joinpath("score.txt").exists(), should_exist)
+                if should_exist:
+                    self.assertEqual(float(folder.joinpath("score.txt").read_text()), 0.5 if num == 0 else 1)
+
+    def test_encode_instance(self) -> None:
+        first = self.history.history[0].generator.instance
+        second = self.history.history[1].generator.instance
+        with TempDir() as target:
+            for num, folder, should_exist in self._encode_attr(target, "instances"):
+                self.assertEqual(folder.joinpath("instance.json").exists(), should_exist)
+                if should_exist:
+                    decoded = TestInstance.decode(folder / "instance.json", 25, Role.generator)
+                    self.assertEqual(decoded, first if num == 0 else second)
+
+    def test_encode_witness(self) -> None:
+        first = self.history.history[0].generator.solution
+        second = self.history.history[1].generator.solution
+        with TempDir() as target:
+            for num, folder, should_exist in self._encode_attr(target, "gen_sols"):
+                self.assertEqual(folder.joinpath("generator_solution.json").exists(), should_exist)
+                if should_exist:
+                    decoded = TestSolution.decode(folder / "generator_solution.json", 25, Role.generator)
+                    self.assertEqual(decoded, first if num == 0 else second)
+
+    def test_encode_solution(self) -> None:
+        first = cast(SolverResult, self.history.history[0].solver).solution
+        second = cast(SolverResult, self.history.history[1].solver).solution
+        with TempDir() as target:
+            for num, folder, should_exist in self._encode_attr(target, "sol_sols"):
+                self.assertEqual(folder.joinpath("solver_solution.json").exists(), should_exist)
+                if should_exist:
+                    decoded = TestSolution.decode(folder / "solver_solution.json", 25, Role.generator)
+                    self.assertEqual(decoded, first if num == 0 else second)
+
+
+class ImprovingScoreTests(TestCase):
+    """Tests the Improving battle score function."""
+
+    @staticmethod
+    def fight(score: float) -> Fight:
+        return Fight(score=score, max_size=25, generator=ProgramRunInfo(), solver=ProgramRunInfo())
+
+    def test_score_equal(self) -> None:
+        battle = Improving(fights=[self.fight(0.7) for _ in range(17)])
+        self.assertAlmostEqual(battle.score(Improving.Config()), 0.7)
+
+    def test_score_cliff(self) -> None:
+        battle = Improving(fights=[self.fight(0), self.fight(0), self.fight(1)])
+        self.assertAlmostEqual(battle.score(Improving.Config()), 1.1 ** 2 / (2.1 + 1.1**2))
+
+    def test_score_increasing(self) -> None:
+        battle = Improving(fights=[self.fight(0), self.fight(0.5), self.fight(1)])
+        self.assertAlmostEqual(battle.score(Improving.Config()), (0.5*1.1 + 1.1**2) / (2.1 + 1.1**2))
+
+    def test_score_dropoff(self) -> None:
+        battle = Improving(fights=[self.fight(1), self.fight(0), self.fight(0)])
+        self.assertAlmostEqual(battle.score(Improving.Config()), 1 / (2.1 + 1.1**2))
 
 if __name__ == "__main__":
     main()

--- a/tests/test_battles.py
+++ b/tests/test_battles.py
@@ -202,7 +202,9 @@ class IteratedTests(IsolatedAsyncioTestCase):
 class TrackingHandler(FightHandler):
     """Fight handler that tracks the passed battle data."""
 
-    def __init__(self, battle: Improving, gen_res: Iterable[GeneratorResult], sol_res: Iterable[SolverResult | None]) -> None:
+    def __init__(
+        self, battle: Improving, gen_res: Iterable[GeneratorResult], sol_res: Iterable[SolverResult | None]
+    ) -> None:
         self.battle = battle
         self.gen_res = iter(gen_res)
         self.sol_res = iter(sol_res)
@@ -234,7 +236,12 @@ class ImprovingTests(IsolatedAsyncioTestCase):
             FightHistory.Fight(1, cls.gen_res(), cls.sol_res()),
         ]
 
-    async def run_battle(self, gen_res: Iterable[GeneratorResult], sol_res: Iterable[SolverResult | None], config: Improving.Config | None = None) -> TrackingHandler:
+    async def run_battle(
+        self,
+        gen_res: Iterable[GeneratorResult],
+        sol_res: Iterable[SolverResult | None],
+        config: Improving.Config | None = None,
+    ) -> TrackingHandler:
         battle = Improving()
         handler = TrackingHandler(battle, gen_res, sol_res)
         await battle.run_battle(handler, config=config or self.config, min_size=5, ui=self.ui)
@@ -379,15 +386,16 @@ class ImprovingScoreTests(TestCase):
 
     def test_score_cliff(self) -> None:
         battle = Improving(fights=[self.fight(0), self.fight(0), self.fight(1)])
-        self.assertAlmostEqual(battle.score(Improving.Config()), 1.1 ** 2 / (2.1 + 1.1**2))
+        self.assertAlmostEqual(battle.score(Improving.Config()), 1.1**2 / (2.1 + 1.1**2))
 
     def test_score_increasing(self) -> None:
         battle = Improving(fights=[self.fight(0), self.fight(0.5), self.fight(1)])
-        self.assertAlmostEqual(battle.score(Improving.Config()), (0.5*1.1 + 1.1**2) / (2.1 + 1.1**2))
+        self.assertAlmostEqual(battle.score(Improving.Config()), (0.5 * 1.1 + 1.1**2) / (2.1 + 1.1**2))
 
     def test_score_dropoff(self) -> None:
         battle = Improving(fights=[self.fight(1), self.fight(0), self.fight(0)])
         self.assertAlmostEqual(battle.score(Improving.Config()), 1 / (2.1 + 1.1**2))
+
 
 if __name__ == "__main__":
     main()

--- a/tests/testsproblem/problem.py
+++ b/tests/testsproblem/problem.py
@@ -1,5 +1,6 @@
 """Problem class built for tests."""
 
+from typing import Any
 from algobattle.problem import Problem, InstanceModel, SolutionModel
 from algobattle.util import Role, ValidationError
 
@@ -8,6 +9,7 @@ class TestInstance(InstanceModel):
     """Artificial problem used for tests."""
 
     semantics: bool
+    extra: Any = None
 
     @property
     def size(self) -> int:
@@ -23,6 +25,7 @@ class TestSolution(SolutionModel[TestInstance]):
 
     semantics: bool
     quality: bool
+    extra: Any = None
 
     def validate_solution(self, instance: TestInstance, role: Role) -> None:
         if not self.semantics:


### PR DESCRIPTION
This adds a new battle type called `Improving`. The idea behind these battles is that teams don't just create instances/solutions from scratch every time, but should improve on previous round's instances/solutions. To do this we basically run an Averaged battle, but also provide the programs with info on the previous rounds. A generator can then e.g. fine tune some parameters to create instances that it sees the solver has trouble handling. More details on this can be found in the battle type section of the docs.

This PR also shuffles around some other code to let battle types access each fight's instances/solutions directly and use config options when calculating scores. No externally visible functionality has been changed. The new battle type and associated classes come with extensive tests.