### PR TITLE
Graph utility methods

### DIFF
--- a/algobattle/types.py
+++ b/algobattle/types.py
@@ -424,7 +424,6 @@ Edge = Annotated[int, IndexInto[InstanceRef.edges]]
 
 def path_in_graph(path: list[Vertex], edge_set: set[tuple[Vertex, Vertex]]):
     """Checks that a path actually exists in the graph."""
-
     for edge in pairwise(path):
         if edge not in edge_set:
             raise ValueError(f"The edge {edge} does not exist in the graph.")
@@ -447,19 +446,18 @@ class DirectedGraph(InstanceModel):
     @cached_property
     def edge_set(self) -> set[tuple[Vertex, Vertex]]:
         """The set of edges in this graph."""
-
         return set(self.edges)
 
     @cache
     def neighbors(self, vertex: Vertex, direction: Literal["all", "outgoing", "incoming"] = "all") -> set[Vertex]:
         """The neighbors of a vertex."""
-
         res = set[Vertex]()
         if direction in {"all", "outgoing"}:
             res |= set(v for (u, v) in self.edges if u == vertex)
         if direction in {"all", "incoming"}:
             res |= set(v for (v, u) in self.edges if u == vertex)
         return res
+
 
 class UndirectedGraph(DirectedGraph):
     """Base instance class for problems on undirected graphs."""
@@ -481,10 +479,9 @@ class UndirectedGraph(DirectedGraph):
     @cached_property
     def edge_set(self) -> set[tuple[Vertex, Vertex]]:
         """The set of edges in this graph.
-        
+
         Normalized to contain every edge in both directions.
         """
-
         return set(self.edges) | set((v, u) for (u, v) in self.edges)
 
     @cache
@@ -526,16 +523,14 @@ class EdgeWeights(DirectedGraph, BaseModel, Generic[Weight]):
     @cached_property
     def edges_with_weights(self) -> Iterator[tuple[tuple[Vertex, Vertex], Weight]]:
         """Iterate over all edges and their weights."""
-
         return zip(self.edges, self.edge_weights)
 
     @cache
     def weight(self, edge: Edge | tuple[Vertex, Vertex]) -> Weight:
         """Returns the weight of an edge.
-        
+
         Raises KeyError if the given edge does not exist.
         """
-
         if isinstance(edge, tuple):
             try:
                 edge = self.edges.index(edge)
@@ -550,6 +545,7 @@ class EdgeWeights(DirectedGraph, BaseModel, Generic[Weight]):
 
         return self.edge_weights[edge]
 
+
 class VertexWeights(DirectedGraph, BaseModel, Generic[Weight]):
     """Mixin for graphs with weighted vertices."""
 
@@ -558,7 +554,6 @@ class VertexWeights(DirectedGraph, BaseModel, Generic[Weight]):
     @cached_property
     def vertices_with_weights(self) -> Iterator[tuple[Vertex, Weight]]:
         """Iterate over all edges and their weights."""
-
         return enumerate(self.vertex_weights)
 
 

--- a/algobattle/types.py
+++ b/algobattle/types.py
@@ -25,6 +25,7 @@ from annotated_types import (
     SupportsLt,
     SupportsMod,
 )
+from itertools import pairwise
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
@@ -63,6 +64,7 @@ __all__ = (
     "DirectedGraph",
     "UndirectedGraph",
     "Edge",
+    "Path",
     "EdgeLen",
     "EdgeWeights",
     "VertexWeights",
@@ -418,6 +420,17 @@ Vertex = SizeIndex
 
 Edge = Annotated[int, IndexInto[InstanceRef.edges]]
 """Type for edges, encoded as indices into `instance.edges`."""
+
+
+def path_in_graph(path: list[Vertex], edge_set: set[tuple[Vertex, Vertex]]):
+    """Checks that a path actually exists in the graph."""
+
+    for edge in pairwise(path):
+        if edge not in edge_set:
+            raise ValueError(f"The edge {edge} does not exist in the graph.")
+
+
+Path = Annotated[list[Vertex], AttributeReferenceValidator(path_in_graph, InstanceRef.edge_set)]
 
 
 class DirectedGraph(InstanceModel):

--- a/docs/instructor/problem/advanced.md
+++ b/docs/instructor/problem/advanced.md
@@ -172,7 +172,7 @@ directionless. Both graph's size is the number of vertices in it.
 
 !!! tip "Associated Annotation Types"
     As you can see in the example above, we also provide several types that are useful in type annotations of graph
-    problems such as `Vertex` or `Edge`. These are documented in more detail in the
+    problems such as `Vertex`, `Edge`, or `Path`. How these function is explained in more detail in the
     [advanced annotations](annotations.md) section.
 
 If you want the problem instance to also contain additional information associated with each vertex and/or each edge
@@ -200,6 +200,11 @@ indexed with the type of the weights you want to use.
 
         ...
     ```
+
+!!! tip
+    These classes also contain some utility methods to easily perform common graph operations. For example,
+    `UndirectedGraph.edge_set` contains all edges in both directions, and the `neighbors` methods lets you quickly
+    access a vertex's neighbours.
 
 ## Comparing Floats
 


### PR DESCRIPTION
Currently some common graph operations like normalizing the edges in an undirected graph to go in both directions or checking if an edge or path is in a graph are pretty annoying due to the way we encode graphs. This PR just adds some utility methods to help with that.